### PR TITLE
Fix categorical distribution validation error

### DIFF
--- a/entropy/architect/hydrator_utils.py
+++ b/entropy/architect/hydrator_utils.py
@@ -424,8 +424,9 @@ def parse_distribution(dist_data: dict, attr_type: str):
             max=dist_data.get("max"),
         )
     elif dist_type == "categorical":
-        options = dist_data.get("options", [])
-        weights = dist_data.get("weights")
+        # Handle explicit null from LLM response (get returns None, not default)
+        options = dist_data.get("options") or []
+        weights = dist_data.get("weights") or []
         if not weights or len(weights) != len(options):
             weights = [1.0 / len(options)] * len(options) if options else []
         return CategoricalDistribution(


### PR DESCRIPTION
…tions

When the LLM returns explicit null for options/weights fields (which is allowed by the JSON schema), dict.get("options", []) returns None instead of the default empty list. This caused Pydantic validation to fail with "Input should be a valid list" error.

Fix: Use `or []` pattern to handle both missing keys and explicit null values.