### PR TITLE
Add sampler module for generating agents from PopulationSpec

### DIFF
--- a/entropy/sampler/__init__.py
+++ b/entropy/sampler/__init__.py
@@ -1,0 +1,58 @@
+"""Sampler module for Entropy population generation.
+
+The sampler is a generic spec interpreter that generates agents from a
+PopulationSpec. It doesn't know about surgeons or farmers - it just
+executes whatever spec it's given.
+
+Usage:
+    from entropy.sampler import sample_population, save_json, save_sqlite
+
+    result = sample_population(spec, count=500, seed=42)
+    save_json(result, "agents.json")
+    # or
+    save_sqlite(result, "agents.db")
+
+Pipeline Position:
+    1. entropy spec → base spec (surgeons.yaml)
+    2. entropy overlay → merged spec (surgeons_ai.yaml) — optional
+    3. entropy sample → agents from whichever spec you provide
+"""
+
+from .core import (
+    sample_population,
+    save_json,
+    save_sqlite,
+    SamplingError,
+    SamplingResult,
+    SamplingStats,
+)
+from .eval_safe import (
+    eval_safe,
+    eval_formula,
+    eval_condition,
+    FormulaError,
+    ConditionError,
+)
+from .distributions import sample_distribution, coerce_to_type
+from .modifiers import apply_modifiers_and_sample
+
+__all__ = [
+    # Core functions
+    "sample_population",
+    "save_json",
+    "save_sqlite",
+    # Result types
+    "SamplingResult",
+    "SamplingStats",
+    "SamplingError",
+    # Evaluation utilities
+    "eval_safe",
+    "eval_formula",
+    "eval_condition",
+    "FormulaError",
+    "ConditionError",
+    # Lower-level functions (for testing/extension)
+    "sample_distribution",
+    "coerce_to_type",
+    "apply_modifiers_and_sample",
+]

--- a/entropy/sampler/core.py
+++ b/entropy/sampler/core.py
@@ -1,0 +1,377 @@
+"""Core sampling loop for generating agents from a PopulationSpec.
+
+The sampler is a generic spec interpreter - it doesn't know about surgeons
+or farmers, it just executes whatever spec it's given.
+"""
+
+import json
+import logging
+import random
+import sqlite3
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Callable
+
+from ..models import PopulationSpec, AttributeSpec
+from .distributions import sample_distribution, coerce_to_type
+from .modifiers import apply_modifiers_and_sample
+from .eval_safe import eval_formula, FormulaError
+
+logger = logging.getLogger(__name__)
+
+
+class SamplingError(Exception):
+    """Raised when sampling fails for an agent."""
+
+    pass
+
+
+@dataclass
+class SamplingStats:
+    """Statistics collected during sampling."""
+
+    # Attribute-level stats
+    attribute_means: dict[str, float] = field(default_factory=dict)
+    attribute_stds: dict[str, float] = field(default_factory=dict)
+    categorical_counts: dict[str, dict[str, int]] = field(default_factory=dict)
+    boolean_counts: dict[str, dict[bool, int]] = field(default_factory=dict)
+
+    # Modifier trigger counts: attr_name -> modifier_index -> count
+    modifier_triggers: dict[str, dict[int, int]] = field(default_factory=dict)
+
+    # Constraint violations (expression constraints)
+    constraint_violations: dict[str, int] = field(default_factory=dict)
+
+    # Condition evaluation warnings
+    condition_warnings: list[str] = field(default_factory=list)
+
+
+@dataclass
+class SamplingResult:
+    """Result of sampling a population."""
+
+    agents: list[dict[str, Any]]
+    meta: dict[str, Any]
+    stats: SamplingStats
+
+
+def sample_population(
+    spec: PopulationSpec,
+    count: int | None = None,
+    seed: int | None = None,
+    on_progress: Callable[[int, int], None] | None = None,
+) -> SamplingResult:
+    """
+    Generate agents from a PopulationSpec.
+
+    Args:
+        spec: The population specification to sample from
+        count: Number of agents to generate (defaults to spec.meta.size)
+        seed: Random seed for reproducibility (None = random)
+        on_progress: Optional callback(current, total) for progress updates
+
+    Returns:
+        SamplingResult with agents list, metadata, and statistics
+
+    Raises:
+        SamplingError: If sampling fails for any agent (e.g., formula error)
+    """
+    # Resolve count
+    n = count if count is not None else spec.meta.size
+
+    # Initialize RNG
+    if seed is None:
+        seed = random.randint(0, 2**31 - 1)
+    rng = random.Random(seed)
+
+    # Build attribute lookup for quick access
+    attr_map: dict[str, AttributeSpec] = {attr.name: attr for attr in spec.attributes}
+
+    # Determine ID padding based on count
+    id_width = len(str(n - 1))
+
+    # Initialize stats
+    stats = SamplingStats()
+    for attr in spec.attributes:
+        if attr.type in ("int", "float"):
+            stats.attribute_means[attr.name] = 0.0
+            stats.attribute_stds[attr.name] = 0.0
+        elif attr.type == "categorical":
+            stats.categorical_counts[attr.name] = {}
+        elif attr.type == "boolean":
+            stats.boolean_counts[attr.name] = {True: 0, False: 0}
+
+        # Initialize modifier trigger counts
+        if attr.sampling.modifiers:
+            stats.modifier_triggers[attr.name] = {
+                i: 0 for i in range(len(attr.sampling.modifiers))
+            }
+
+    # Collect numeric values for std calculation
+    numeric_values: dict[str, list[float]] = {
+        attr.name: [] for attr in spec.attributes if attr.type in ("int", "float")
+    }
+
+    agents: list[dict[str, Any]] = []
+
+    for i in range(n):
+        agent = _sample_single_agent(
+            spec, attr_map, rng, i, id_width, stats, numeric_values
+        )
+        agents.append(agent)
+
+        if on_progress:
+            on_progress(i + 1, n)
+
+    # Compute final statistics
+    _finalize_stats(stats, numeric_values, n)
+
+    # Check expression constraints
+    _check_expression_constraints(spec, agents, stats)
+
+    # Build metadata
+    meta = {
+        "spec": spec.meta.description,
+        "count": n,
+        "seed": seed,
+        "generated_at": datetime.now().isoformat(),
+    }
+
+    return SamplingResult(agents=agents, meta=meta, stats=stats)
+
+
+def _sample_single_agent(
+    spec: PopulationSpec,
+    attr_map: dict[str, AttributeSpec],
+    rng: random.Random,
+    index: int,
+    id_width: int,
+    stats: SamplingStats,
+    numeric_values: dict[str, list[float]],
+) -> dict[str, Any]:
+    """Sample a single agent following the sampling order."""
+    agent: dict[str, Any] = {"_id": f"agent_{index:0{id_width}d}"}
+
+    for attr_name in spec.sampling_order:
+        attr = attr_map.get(attr_name)
+        if attr is None:
+            logger.warning(f"Attribute '{attr_name}' in sampling_order not found")
+            continue
+
+        try:
+            value = _sample_attribute(attr, rng, agent, stats)
+        except FormulaError as e:
+            raise SamplingError(
+                f"Agent {index}: Failed to sample '{attr_name}': {e}"
+            ) from e
+
+        # Coerce to declared type
+        value = coerce_to_type(value, attr.type)
+
+        # Apply hard constraints (min/max clamping)
+        value = _apply_hard_constraints(value, attr)
+
+        agent[attr_name] = value
+
+        # Update stats
+        _update_stats(attr, value, stats, numeric_values)
+
+    return agent
+
+
+def _sample_attribute(
+    attr: AttributeSpec,
+    rng: random.Random,
+    agent: dict[str, Any],
+    stats: SamplingStats,
+) -> Any:
+    """Sample a single attribute based on its strategy."""
+    strategy = attr.sampling.strategy
+
+    if strategy == "derived":
+        # Compute from formula
+        if not attr.sampling.formula:
+            raise FormulaError(f"Derived attribute '{attr.name}' has no formula")
+        return eval_formula(attr.sampling.formula, agent)
+
+    elif strategy == "independent":
+        # Sample directly from distribution
+        if not attr.sampling.distribution:
+            raise FormulaError(
+                f"Independent attribute '{attr.name}' has no distribution"
+            )
+        return sample_distribution(attr.sampling.distribution, rng, agent)
+
+    elif strategy == "conditional":
+        # Sample with modifiers
+        if not attr.sampling.distribution:
+            raise FormulaError(
+                f"Conditional attribute '{attr.name}' has no distribution"
+            )
+
+        if not attr.sampling.modifiers:
+            # No modifiers, sample directly
+            return sample_distribution(attr.sampling.distribution, rng, agent)
+
+        value, triggered = apply_modifiers_and_sample(
+            attr.sampling.distribution,
+            attr.sampling.modifiers,
+            rng,
+            agent,
+        )
+
+        # Update modifier trigger stats
+        if attr.name in stats.modifier_triggers:
+            for idx in triggered:
+                stats.modifier_triggers[attr.name][idx] += 1
+
+        return value
+
+    else:
+        raise FormulaError(f"Unknown sampling strategy: {strategy}")
+
+
+def _apply_hard_constraints(value: Any, attr: AttributeSpec) -> Any:
+    """Apply hard_min and hard_max constraints (clamping)."""
+    if attr.type not in ("int", "float"):
+        return value
+
+    for constraint in attr.constraints:
+        # Handle both legacy "min"/"max" and new "hard_min"/"hard_max"
+        if constraint.type in ("hard_min", "min") and constraint.value is not None:
+            if isinstance(value, (int, float)):
+                value = max(value, constraint.value)
+        elif constraint.type in ("hard_max", "max") and constraint.value is not None:
+            if isinstance(value, (int, float)):
+                value = min(value, constraint.value)
+
+    return value
+
+
+def _update_stats(
+    attr: AttributeSpec,
+    value: Any,
+    stats: SamplingStats,
+    numeric_values: dict[str, list[float]],
+) -> None:
+    """Update running statistics for an attribute."""
+    if attr.type in ("int", "float") and isinstance(value, (int, float)):
+        numeric_values[attr.name].append(float(value))
+    elif attr.type == "categorical":
+        str_value = str(value)
+        if str_value not in stats.categorical_counts[attr.name]:
+            stats.categorical_counts[attr.name][str_value] = 0
+        stats.categorical_counts[attr.name][str_value] += 1
+    elif attr.type == "boolean":
+        bool_value = bool(value)
+        stats.boolean_counts[attr.name][bool_value] += 1
+
+
+def _finalize_stats(
+    stats: SamplingStats,
+    numeric_values: dict[str, list[float]],
+    n: int,
+) -> None:
+    """Compute final mean/std for numeric attributes."""
+    for name, values in numeric_values.items():
+        if not values:
+            continue
+        mean = sum(values) / len(values)
+        stats.attribute_means[name] = mean
+        if len(values) > 1:
+            variance = sum((v - mean) ** 2 for v in values) / (len(values) - 1)
+            stats.attribute_stds[name] = variance**0.5
+        else:
+            stats.attribute_stds[name] = 0.0
+
+
+def _check_expression_constraints(
+    spec: PopulationSpec,
+    agents: list[dict[str, Any]],
+    stats: SamplingStats,
+) -> None:
+    """Check expression constraints and count violations."""
+    from .eval_safe import eval_condition
+
+    for attr in spec.attributes:
+        for constraint in attr.constraints:
+            if constraint.type == "expression" and constraint.expression:
+                violation_count = 0
+                for agent in agents:
+                    # Add 'value' to context for constraints that reference it
+                    context = dict(agent)
+                    if attr.name in agent:
+                        context["value"] = agent[attr.name]
+
+                    try:
+                        if not eval_condition(constraint.expression, context):
+                            violation_count += 1
+                    except Exception:
+                        # Skip malformed constraints
+                        pass
+
+                if violation_count > 0:
+                    key = f"{attr.name}: {constraint.expression}"
+                    stats.constraint_violations[key] = violation_count
+
+
+def save_json(result: SamplingResult, path: Path | str) -> None:
+    """Save sampling result to JSON file."""
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    output = {
+        "meta": result.meta,
+        "agents": result.agents,
+    }
+
+    with open(path, "w") as f:
+        json.dump(output, f, indent=2, default=str)
+
+
+def save_sqlite(result: SamplingResult, path: Path | str) -> None:
+    """Save sampling result to SQLite database."""
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Remove existing file to start fresh
+    if path.exists():
+        path.unlink()
+
+    conn = sqlite3.connect(path)
+    cursor = conn.cursor()
+
+    # Create tables
+    cursor.execute("""
+        CREATE TABLE meta (
+            key TEXT PRIMARY KEY,
+            value TEXT
+        )
+    """)
+
+    cursor.execute("""
+        CREATE TABLE agents (
+            id TEXT PRIMARY KEY,
+            attributes JSON
+        )
+    """)
+
+    # Insert metadata
+    for key, value in result.meta.items():
+        cursor.execute(
+            "INSERT INTO meta (key, value) VALUES (?, ?)",
+            (key, json.dumps(value, default=str)),
+        )
+
+    # Insert agents
+    for agent in result.agents:
+        agent_id = agent.get("_id", "")
+        # Store full agent as JSON (including _id for consistency)
+        cursor.execute(
+            "INSERT INTO agents (id, attributes) VALUES (?, ?)",
+            (agent_id, json.dumps(agent, default=str)),
+        )
+
+    conn.commit()
+    conn.close()

--- a/entropy/sampler/distributions.py
+++ b/entropy/sampler/distributions.py
@@ -1,0 +1,233 @@
+"""Type-specific distribution sampling.
+
+Handles sampling from all 6 distribution types:
+- normal: Gaussian with optional min/max clamping
+- lognormal: Log-normal distribution
+- uniform: Uniform between min and max
+- beta: Beta distribution (0-1 output, useful for proportions)
+- categorical: Weighted random selection from options
+- boolean: Bernoulli trial with probability_true
+"""
+
+import random
+import re
+from typing import Any
+
+from ..models import (
+    NormalDistribution,
+    LognormalDistribution,
+    UniformDistribution,
+    BetaDistribution,
+    CategoricalDistribution,
+    BooleanDistribution,
+    Distribution,
+)
+from .eval_safe import eval_safe, FormulaError
+
+
+def sample_distribution(
+    dist: Distribution,
+    rng: random.Random,
+    agent: dict[str, Any] | None = None,
+) -> Any:
+    """
+    Sample a value from a distribution.
+
+    Args:
+        dist: Distribution configuration
+        rng: Random number generator (seeded for reproducibility)
+        agent: Current agent's already-sampled values (for mean_formula/std_formula)
+
+    Returns:
+        Sampled value (float, str, or bool depending on distribution type)
+
+    Raises:
+        FormulaError: If mean_formula/std_formula evaluation fails
+        ValueError: If distribution type is unknown
+    """
+    if isinstance(dist, NormalDistribution):
+        return _sample_normal(dist, rng, agent)
+    elif isinstance(dist, LognormalDistribution):
+        return _sample_lognormal(dist, rng, agent)
+    elif isinstance(dist, UniformDistribution):
+        return _sample_uniform(dist, rng)
+    elif isinstance(dist, BetaDistribution):
+        return _sample_beta(dist, rng)
+    elif isinstance(dist, CategoricalDistribution):
+        return _sample_categorical(dist, rng)
+    elif isinstance(dist, BooleanDistribution):
+        return _sample_boolean(dist, rng)
+    else:
+        raise ValueError(f"Unknown distribution type: {type(dist)}")
+
+
+def _resolve_param(
+    static_value: float | None,
+    formula: str | None,
+    agent: dict[str, Any] | None,
+    param_name: str,
+) -> float:
+    """Resolve a parameter that may be static or formula-based."""
+    if static_value is not None:
+        return static_value
+    if formula is not None:
+        if agent is None:
+            raise FormulaError(
+                f"{param_name}_formula '{formula}' requires agent context"
+            )
+        result = eval_safe(formula, agent)
+        return float(result)
+    raise FormulaError(f"Neither {param_name} nor {param_name}_formula provided")
+
+
+def _sample_normal(
+    dist: NormalDistribution,
+    rng: random.Random,
+    agent: dict[str, Any] | None,
+) -> float:
+    """Sample from normal distribution with optional formula-based parameters."""
+    mean = _resolve_param(dist.mean, dist.mean_formula, agent, "mean")
+    std = _resolve_param(dist.std, dist.std_formula, agent, "std") if (dist.std is not None or dist.std_formula is not None) else 1.0
+
+    value = rng.gauss(mean, std)
+
+    # Apply min/max clamping
+    if dist.min is not None:
+        value = max(value, dist.min)
+    if dist.max is not None:
+        value = min(value, dist.max)
+
+    return value
+
+
+def _sample_lognormal(
+    dist: LognormalDistribution,
+    rng: random.Random,
+    agent: dict[str, Any] | None,
+) -> float:
+    """Sample from lognormal distribution."""
+    mean = _resolve_param(dist.mean, dist.mean_formula, agent, "mean")
+    std = _resolve_param(dist.std, dist.std_formula, agent, "std") if (dist.std is not None or dist.std_formula is not None) else 1.0
+
+    value = rng.lognormvariate(mean, std)
+
+    # Apply min/max clamping
+    if dist.min is not None:
+        value = max(value, dist.min)
+    if dist.max is not None:
+        value = min(value, dist.max)
+
+    return value
+
+
+def _sample_uniform(dist: UniformDistribution, rng: random.Random) -> float:
+    """Sample from uniform distribution."""
+    return rng.uniform(dist.min, dist.max)
+
+
+def _sample_beta(dist: BetaDistribution, rng: random.Random) -> float:
+    """Sample from beta distribution (outputs 0-1, optionally scaled)."""
+    value = rng.betavariate(dist.alpha, dist.beta)
+
+    # Scale if min/max provided
+    if dist.min is not None and dist.max is not None:
+        value = dist.min + value * (dist.max - dist.min)
+
+    return value
+
+
+def _sample_categorical(
+    dist: CategoricalDistribution,
+    rng: random.Random,
+    weights: list[float] | None = None,
+) -> str:
+    """
+    Sample from categorical distribution.
+
+    Args:
+        dist: Categorical distribution with options and weights
+        rng: Random number generator
+        weights: Override weights (used when modifiers apply)
+
+    Returns:
+        Selected option string
+    """
+    use_weights = weights if weights is not None else dist.weights
+    return rng.choices(dist.options, weights=use_weights, k=1)[0]
+
+
+def _sample_boolean(
+    dist: BooleanDistribution,
+    rng: random.Random,
+    probability: float | None = None,
+) -> bool:
+    """
+    Sample from boolean distribution.
+
+    Args:
+        dist: Boolean distribution with probability_true
+        rng: Random number generator
+        probability: Override probability (used when modifiers apply)
+
+    Returns:
+        True or False
+    """
+    p = probability if probability is not None else dist.probability_true
+    return rng.random() < p
+
+
+def coerce_to_type(value: Any, attr_type: str) -> Any:
+    """
+    Coerce sampled value to the declared attribute type.
+
+    Handles mismatches between distribution output and attr.type:
+    - Categorical options like "6+" → int 6
+    - Float → int via rounding
+    - String booleans → bool
+
+    Args:
+        value: Sampled value
+        attr_type: Declared type ("int", "float", "categorical", "boolean")
+
+    Returns:
+        Value coerced to the appropriate type
+    """
+    if attr_type == "int":
+        if isinstance(value, str):
+            # Handle categorical options like "1", "2", "5+", "6+"
+            # Strip non-digit characters and use numeric floor
+            digits = re.sub(r"[^\d]", "", value)
+            if digits:
+                return int(digits)
+            # If no digits found, try direct conversion
+            try:
+                return int(float(value))
+            except ValueError:
+                return 0
+        elif isinstance(value, (int, float)):
+            return round(value)
+        return int(value)
+
+    elif attr_type == "float":
+        if isinstance(value, str):
+            digits = re.sub(r"[^\d.]", "", value)
+            if digits:
+                return float(digits)
+            try:
+                return float(value)
+            except ValueError:
+                return 0.0
+        return float(value)
+
+    elif attr_type == "boolean":
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            return value.lower() in ("true", "1", "yes")
+        return bool(value)
+
+    elif attr_type == "categorical":
+        # Keep as string
+        return str(value)
+
+    return value

--- a/entropy/sampler/eval_safe.py
+++ b/entropy/sampler/eval_safe.py
@@ -1,0 +1,122 @@
+"""Safe expression evaluation for formulas and conditions.
+
+Provides a restricted eval environment that only allows safe builtins,
+preventing file access, imports, and other dangerous operations.
+"""
+
+from typing import Any
+
+# Safe builtins allowed in formula/condition evaluation
+SAFE_BUILTINS = {
+    "True": True,
+    "False": False,
+    "None": None,
+    "abs": abs,
+    "min": min,
+    "max": max,
+    "round": round,
+    "int": int,
+    "float": float,
+    "str": str,
+    "len": len,
+    "sum": sum,
+    "all": all,
+    "any": any,
+    "bool": bool,
+}
+
+
+class FormulaError(Exception):
+    """Raised when formula evaluation fails."""
+
+    pass
+
+
+class ConditionError(Exception):
+    """Raised when condition evaluation fails."""
+
+    pass
+
+
+def eval_safe(expression: str, context: dict[str, Any]) -> Any:
+    """
+    Safely evaluate a Python expression with restricted builtins.
+
+    Args:
+        expression: Python expression string (e.g., "age - 28", "role == 'chief'")
+        context: Dictionary of variable names to values
+
+    Returns:
+        Result of evaluating the expression
+
+    Raises:
+        FormulaError: If evaluation fails
+
+    Example:
+        >>> eval_safe("max(0, age - 26)", {"age": 45})
+        19
+        >>> eval_safe("role == 'chief'", {"role": "resident"})
+        False
+    """
+    # Create restricted globals with only safe builtins
+    restricted_globals = {"__builtins__": SAFE_BUILTINS}
+
+    # Merge context into local namespace
+    local_vars = dict(context)
+
+    try:
+        return eval(expression, restricted_globals, local_vars)
+    except Exception as e:
+        raise FormulaError(f"Failed to evaluate '{expression}': {e}") from e
+
+
+def eval_formula(formula: str, agent: dict[str, Any]) -> Any:
+    """
+    Evaluate a formula expression using agent attributes.
+
+    This is used for derived attributes where the value is computed
+    from other attributes (e.g., years_experience = age - 26).
+
+    Args:
+        formula: Python expression string
+        agent: Dictionary of already-sampled attribute values
+
+    Returns:
+        Computed value
+
+    Raises:
+        FormulaError: If formula evaluation fails
+    """
+    try:
+        return eval_safe(formula, agent)
+    except FormulaError:
+        raise
+    except Exception as e:
+        raise FormulaError(f"Formula '{formula}' failed: {e}") from e
+
+
+def eval_condition(condition: str, agent: dict[str, Any]) -> bool:
+    """
+    Evaluate a condition expression to determine if a modifier applies.
+
+    Unlike formulas, condition failures are non-fatal - they just mean
+    the modifier doesn't apply.
+
+    Args:
+        condition: Python boolean expression (e.g., "age < 32")
+        agent: Dictionary of already-sampled attribute values
+
+    Returns:
+        True if condition is met, False otherwise
+
+    Note:
+        Returns False (not raises) on evaluation errors, since a failed
+        condition just means the modifier doesn't apply.
+    """
+    try:
+        result = eval_safe(condition, agent)
+        return bool(result)
+    except Exception:
+        # Condition failures are warnings, not errors
+        # The modifier just doesn't apply
+        return False

--- a/entropy/sampler/modifiers.py
+++ b/entropy/sampler/modifiers.py
@@ -1,0 +1,237 @@
+"""Modifier application for conditional sampling.
+
+Modifiers adjust distributions based on agent attributes:
+- Numeric (multiply/add): All matching modifiers stack
+- Categorical (weight_overrides): Last matching modifier wins
+- Boolean (probability_override): Last matching modifier wins
+"""
+
+import logging
+import random
+from typing import Any
+
+from ..models import (
+    Modifier,
+    Distribution,
+    NormalDistribution,
+    LognormalDistribution,
+    UniformDistribution,
+    BetaDistribution,
+    CategoricalDistribution,
+    BooleanDistribution,
+)
+from .eval_safe import eval_condition
+from .distributions import (
+    _sample_normal,
+    _sample_lognormal,
+    _sample_uniform,
+    _sample_beta,
+    _sample_categorical,
+    _sample_boolean,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def apply_modifiers_and_sample(
+    dist: Distribution,
+    modifiers: list[Modifier],
+    rng: random.Random,
+    agent: dict[str, Any],
+) -> tuple[Any, list[int]]:
+    """
+    Apply matching modifiers to a distribution and sample.
+
+    Args:
+        dist: Base distribution configuration
+        modifiers: List of conditional modifiers
+        rng: Random number generator
+        agent: Current agent's already-sampled attribute values
+
+    Returns:
+        Tuple of (sampled_value, list of indices of triggered modifiers)
+    """
+    triggered_indices: list[int] = []
+
+    # Check which modifiers apply
+    matching_modifiers: list[tuple[int, Modifier]] = []
+    for i, mod in enumerate(modifiers):
+        try:
+            if eval_condition(mod.when, agent):
+                matching_modifiers.append((i, mod))
+                triggered_indices.append(i)
+        except Exception as e:
+            # Log warning but continue - condition failure means modifier doesn't apply
+            logger.warning(f"Modifier condition '{mod.when}' failed: {e}")
+
+    # Route to type-specific handler
+    if isinstance(dist, (NormalDistribution, LognormalDistribution)):
+        value = _apply_numeric_modifiers(dist, matching_modifiers, rng, agent)
+    elif isinstance(dist, UniformDistribution):
+        value = _apply_uniform_modifiers(dist, matching_modifiers, rng)
+    elif isinstance(dist, BetaDistribution):
+        value = _apply_beta_modifiers(dist, matching_modifiers, rng)
+    elif isinstance(dist, CategoricalDistribution):
+        value = _apply_categorical_modifiers(dist, matching_modifiers, rng)
+    elif isinstance(dist, BooleanDistribution):
+        value = _apply_boolean_modifiers(dist, matching_modifiers, rng)
+    else:
+        raise ValueError(f"Unknown distribution type: {type(dist)}")
+
+    return value, triggered_indices
+
+
+def _apply_numeric_modifiers(
+    dist: NormalDistribution | LognormalDistribution,
+    matching: list[tuple[int, Modifier]],
+    rng: random.Random,
+    agent: dict[str, Any],
+) -> float:
+    """
+    Apply numeric modifiers (multiply/add stack).
+
+    All matching modifiers are applied in sequence:
+    - multiply values are multiplied together
+    - add values are summed
+    - Final: (base_sample * total_multiply) + total_add
+    """
+    # Sample from base distribution first
+    if isinstance(dist, NormalDistribution):
+        base_value = _sample_normal(dist, rng, agent)
+    else:
+        base_value = _sample_lognormal(dist, rng, agent)
+
+    if not matching:
+        return base_value
+
+    # Stack modifiers
+    total_multiply = 1.0
+    total_add = 0.0
+
+    for _, mod in matching:
+        if mod.multiply is not None:
+            total_multiply *= mod.multiply
+        if mod.add is not None:
+            total_add += mod.add
+
+    modified_value = (base_value * total_multiply) + total_add
+
+    # Re-apply min/max clamping after modification
+    if dist.min is not None:
+        modified_value = max(modified_value, dist.min)
+    if dist.max is not None:
+        modified_value = min(modified_value, dist.max)
+
+    return modified_value
+
+
+def _apply_uniform_modifiers(
+    dist: UniformDistribution,
+    matching: list[tuple[int, Modifier]],
+    rng: random.Random,
+) -> float:
+    """Apply modifiers to uniform distribution (multiply/add on sampled value)."""
+    base_value = _sample_uniform(dist, rng)
+
+    if not matching:
+        return base_value
+
+    total_multiply = 1.0
+    total_add = 0.0
+
+    for _, mod in matching:
+        if mod.multiply is not None:
+            total_multiply *= mod.multiply
+        if mod.add is not None:
+            total_add += mod.add
+
+    return (base_value * total_multiply) + total_add
+
+
+def _apply_beta_modifiers(
+    dist: BetaDistribution,
+    matching: list[tuple[int, Modifier]],
+    rng: random.Random,
+) -> float:
+    """Apply modifiers to beta distribution (multiply/add on sampled value)."""
+    base_value = _sample_beta(dist, rng)
+
+    if not matching:
+        return base_value
+
+    total_multiply = 1.0
+    total_add = 0.0
+
+    for _, mod in matching:
+        if mod.multiply is not None:
+            total_multiply *= mod.multiply
+        if mod.add is not None:
+            total_add += mod.add
+
+    modified_value = (base_value * total_multiply) + total_add
+
+    # Clamp to [0, 1] for proportion attributes
+    if dist.min is None and dist.max is None:
+        modified_value = max(0.0, min(1.0, modified_value))
+
+    return modified_value
+
+
+def _apply_categorical_modifiers(
+    dist: CategoricalDistribution,
+    matching: list[tuple[int, Modifier]],
+    rng: random.Random,
+) -> str:
+    """
+    Apply categorical modifiers (last weight_override wins).
+
+    Note: If modifiers only have multiply/add (legacy numeric modifiers on categorical),
+    we ignore them and use base weights.
+    """
+    # Find the last modifier with weight_overrides
+    override_weights: list[float] | None = None
+
+    for _, mod in matching:
+        if mod.weight_overrides:
+            # Build new weights list from overrides
+            new_weights = []
+            for option in dist.options:
+                if option in mod.weight_overrides:
+                    new_weights.append(mod.weight_overrides[option])
+                else:
+                    # Keep original weight for options not in override
+                    idx = dist.options.index(option)
+                    new_weights.append(dist.weights[idx])
+            override_weights = new_weights
+
+    return _sample_categorical(dist, rng, override_weights)
+
+
+def _apply_boolean_modifiers(
+    dist: BooleanDistribution,
+    matching: list[tuple[int, Modifier]],
+    rng: random.Random,
+) -> bool:
+    """
+    Apply boolean modifiers (last probability_override wins).
+
+    If modifiers use multiply/add instead of probability_override,
+    apply to probability: new_prob = (base_prob * multiply) + add, clamped to [0,1].
+    """
+    probability = dist.probability_true
+
+    for _, mod in matching:
+        if mod.probability_override is not None:
+            # Direct override wins
+            probability = mod.probability_override
+        else:
+            # Apply multiply/add to probability
+            if mod.multiply is not None:
+                probability *= mod.multiply
+            if mod.add is not None:
+                probability += mod.add
+
+    # Clamp probability to [0, 1]
+    probability = max(0.0, min(1.0, probability))
+
+    return _sample_boolean(dist, rng, probability)


### PR DESCRIPTION
Implements the spec interpreter that generates agents from YAML specs:

- entropy/sampler/eval_safe.py: Safe expression evaluation for formulas and conditions with restricted builtins
- entropy/sampler/distributions.py: Sampling from all 6 distribution types (normal, lognormal, uniform, beta, categorical, boolean) with support for mean_formula/std_formula
- entropy/sampler/modifiers.py: Modifier application with proper stacking rules (numeric multiply/add stack, categorical/boolean last wins)
- entropy/sampler/core.py: Main sampling loop following sampling_order, handling all three strategies (independent, derived, conditional)
- entropy/sampler/__init__.py: Module exports

CLI command: entropy sample <spec.yaml> -o <output> [options]
- Supports JSON and SQLite output formats
- Progress bar for large populations (100+)
- --report flag shows distribution summaries and modifier triggers
- --skip-validation allows sampling despite validator errors
- Deterministic seeding for reproducibility