### PR TITLE
Refactor: Integrate OpenRouter and LLM model profiles

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,12 +1,59 @@
-# OpenAI API Key (required for Phase 1 & 2)
-OPENAI_API_KEY=sk-...
+# =============================================================================
+# OpenRouter Configuration (Primary LLM Provider)
+# =============================================================================
+OPENROUTER_API_KEY=sk-or-...
 
-# LM Studio (required for Phase 3 simulation)
+# =============================================================================
+# Global Model Defaults
+# =============================================================================
+# These are used when no phase-specific model is configured
+
+# Fast model for simple_call (no reasoning needed)
+DEFAULT_FAST_MODEL=openai/gpt-4o-mini
+
+# Reasoning model for reasoning_call (reasoning, no web search)
+DEFAULT_REASONING_MODEL=anthropic/claude-sonnet-4
+
+# Research model for agentic_research (reasoning + web search)
+DEFAULT_RESEARCH_MODEL=openai/gpt-4o
+
+# =============================================================================
+# Phase-Specific Model Overrides (Optional)
+# =============================================================================
+# Leave empty to use global defaults
+
+# Population Phase (Phase 1: Population Creation)
+# POPULATION_FAST_MODEL=
+# POPULATION_REASONING_MODEL=
+# POPULATION_RESEARCH_MODEL=
+
+# Scenario Phase (Phase 2: Scenario Injection)
+# SCENARIO_FAST_MODEL=
+# SCENARIO_REASONING_MODEL=
+# SCENARIO_RESEARCH_MODEL=
+
+# Simulation Phase (Phase 3: Simulation)
+# SIMULATION_FAST_MODEL=
+# SIMULATION_REASONING_MODEL=
+# SIMULATION_RESEARCH_MODEL=
+
+# =============================================================================
+# LM Studio (Local models for Phase 3)
+# =============================================================================
 LMSTUDIO_BASE_URL=http://localhost:1234/v1
 LMSTUDIO_MODEL=llama-3.2-3b
 
+# =============================================================================
 # Database
+# =============================================================================
 DB_PATH=./storage/entropy.db
 
-# Defaults
+# =============================================================================
+# Other Defaults
+# =============================================================================
 DEFAULT_POPULATION_SIZE=1000
+
+# =============================================================================
+# Legacy (for backward compatibility)
+# =============================================================================
+# OPENAI_API_KEY=sk-...

--- a/entropy/config.py
+++ b/entropy/config.py
@@ -1,13 +1,85 @@
-"""Configuration management for Entropy."""
+"""Configuration management for Entropy.
+
+Includes:
+- Settings: Environment-based configuration
+- ModelProfile: Per-task model configuration
+- PhaseProfiles: Phase-specific model defaults
+"""
 
 from pathlib import Path
 from functools import lru_cache
+from typing import Literal
 
+from pydantic import BaseModel, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
+# =============================================================================
+# Model Profile Configuration
+# =============================================================================
+
+
+class ModelProfile(BaseModel):
+    """Configuration for a specific workflow task.
+
+    Defines which models to use for different types of LLM calls,
+    along with reasoning effort level.
+
+    Attributes:
+        fast: Model for simple_call (fast, no reasoning)
+        reasoning: Model for reasoning_call (with reasoning, no web search)
+        research: Model for agentic_research (with reasoning + web search)
+        reasoning_effort: Effort level for reasoning models
+    """
+
+    fast: str = Field(
+        default="openai/gpt-4o-mini",
+        description="Model for simple_call",
+    )
+    reasoning: str = Field(
+        default="anthropic/claude-sonnet-4",
+        description="Model for reasoning_call",
+    )
+    research: str = Field(
+        default="openai/gpt-4o",
+        description="Model for agentic_research",
+    )
+    reasoning_effort: Literal["low", "medium", "high"] = Field(
+        default="low",
+        description="Reasoning effort level",
+    )
+
+
+class PhaseProfiles(BaseModel):
+    """Model profiles organized by workflow phase.
+
+    Allows different model configurations for each phase of the
+    Entropy workflow.
+
+    Attributes:
+        population: Profile for population creation (Phase 1)
+        scenario: Profile for scenario injection (Phase 2)
+        simulation: Profile for simulation (Phase 3)
+    """
+
+    population: ModelProfile = Field(default_factory=ModelProfile)
+    scenario: ModelProfile = Field(default_factory=ModelProfile)
+    simulation: ModelProfile = Field(default_factory=ModelProfile)
+
+
+# =============================================================================
+# Application Settings
+# =============================================================================
+
+
 class Settings(BaseSettings):
-    """Application settings loaded from environment variables."""
+    """Application settings loaded from environment variables.
+
+    Supports hierarchical model configuration:
+    1. Global defaults (DEFAULT_*_MODEL)
+    2. Phase defaults (POPULATION_*_MODEL, SCENARIO_*_MODEL, SIMULATION_*_MODEL)
+    3. Task overrides (passed directly to LLM functions)
+    """
 
     model_config = SettingsConfigDict(
         env_file=".env",
@@ -15,10 +87,33 @@ class Settings(BaseSettings):
         extra="ignore",
     )
 
-    # OpenAI
+    # OpenRouter (primary LLM provider)
+    openrouter_api_key: str = ""
+
+    # Legacy OpenAI (for backward compatibility)
     openai_api_key: str = ""
 
-    # LM Studio (Phase 3)
+    # Global model defaults
+    default_fast_model: str = "openai/gpt-4o-mini"
+    default_reasoning_model: str = "anthropic/claude-sonnet-4"
+    default_research_model: str = "openai/gpt-4o"
+
+    # Population phase overrides
+    population_fast_model: str = ""
+    population_reasoning_model: str = ""
+    population_research_model: str = ""
+
+    # Scenario phase overrides
+    scenario_fast_model: str = ""
+    scenario_reasoning_model: str = ""
+    scenario_research_model: str = ""
+
+    # Simulation phase overrides
+    simulation_fast_model: str = ""
+    simulation_reasoning_model: str = ""
+    simulation_research_model: str = ""
+
+    # LM Studio (Phase 3 local models)
     lmstudio_base_url: str = "http://localhost:1234/v1"
     lmstudio_model: str = "llama-3.2-3b"
 
@@ -42,8 +137,70 @@ class Settings(BaseSettings):
         path.mkdir(parents=True, exist_ok=True)
         return path
 
+    def get_phase_profiles(self) -> PhaseProfiles:
+        """Build PhaseProfiles from environment settings.
+
+        Phase-specific settings override global defaults.
+
+        Returns:
+            PhaseProfiles with all phases configured
+        """
+        return PhaseProfiles(
+            population=ModelProfile(
+                fast=self.population_fast_model or self.default_fast_model,
+                reasoning=self.population_reasoning_model or self.default_reasoning_model,
+                research=self.population_research_model or self.default_research_model,
+            ),
+            scenario=ModelProfile(
+                fast=self.scenario_fast_model or self.default_fast_model,
+                reasoning=self.scenario_reasoning_model or self.default_reasoning_model,
+                research=self.scenario_research_model or self.default_research_model,
+            ),
+            simulation=ModelProfile(
+                fast=self.simulation_fast_model or self.default_fast_model,
+                reasoning=self.simulation_reasoning_model or self.default_reasoning_model,
+                research=self.simulation_research_model or self.default_research_model,
+            ),
+        )
+
+    def get_default_profile(self) -> ModelProfile:
+        """Get the default model profile (global defaults).
+
+        Returns:
+            ModelProfile with global default models
+        """
+        return ModelProfile(
+            fast=self.default_fast_model,
+            reasoning=self.default_reasoning_model,
+            research=self.default_research_model,
+        )
+
 
 @lru_cache
 def get_settings() -> Settings:
     """Get cached settings instance."""
     return Settings()
+
+
+def get_profile(phase: str | None = None) -> ModelProfile:
+    """Get model profile for a specific phase or global default.
+
+    Args:
+        phase: Phase name ("population", "scenario", "simulation") or None
+
+    Returns:
+        ModelProfile for the specified phase or global default
+    """
+    settings = get_settings()
+
+    if phase is None:
+        return settings.get_default_profile()
+
+    profiles = settings.get_phase_profiles()
+    phase_map = {
+        "population": profiles.population,
+        "scenario": profiles.scenario,
+        "simulation": profiles.simulation,
+    }
+
+    return phase_map.get(phase, settings.get_default_profile())

--- a/entropy/core/__init__.py
+++ b/entropy/core/__init__.py
@@ -1,16 +1,19 @@
 """Core infrastructure for Entropy.
 
 This package contains shared infrastructure used across all phases:
-- llm: OpenAI API wrappers for LLM calls
+- llm: LLM function wrappers (simple_call, reasoning_call, agentic_research)
+- providers: OpenRouter client and provider utilities
 - models: All Pydantic models organized by domain
 
 Note: LLM functions are not eagerly imported to avoid requiring openai
 dependency for model imports. Use:
     from entropy.core.llm import simple_call
+    from entropy.core.providers import get_openrouter_client
 """
 
-# Don't eagerly import llm to allow core.models to work without openai
+# Don't eagerly import llm/providers to allow core.models to work without openai
 __all__ = [
     "llm",
     "models",
+    "providers",
 ]

--- a/entropy/core/llm.py
+++ b/entropy/core/llm.py
@@ -1,9 +1,14 @@
-"""LLM clients for Entropy - Architect Layer.
+"""LLM clients for Entropy - OpenRouter-based with Model Profiles.
 
 Three main functions:
-- simple_call: Fast, no reasoning, no web search (gpt-5-mini)
-- reasoning_call: With reasoning, no web search (gpt-5)
-- agentic_research: With reasoning AND web search (gpt-5)
+- simple_call: Fast, no reasoning, no web search
+- reasoning_call: With reasoning, no web search
+- agentic_research: With reasoning AND web search
+
+All functions support:
+- ModelProfile for consistent phase configuration
+- Explicit model override for fine-grained control
+- Backward-compatible defaults
 """
 
 import json
@@ -11,9 +16,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-from openai import OpenAI
-
-from ..config import get_settings
+from ..config import get_settings, ModelProfile, get_profile
+from .providers import get_openrouter_client
 
 
 def _get_logs_dir() -> Path:
@@ -57,17 +61,71 @@ def _log_request_response(
     print(f"  [Logged to {log_file}]")
 
 
-def get_openai_client() -> OpenAI:
-    """Get OpenAI client."""
-    settings = get_settings()
-    return OpenAI(api_key=settings.openai_api_key)
+def _resolve_model(
+    model: str | None,
+    profile: ModelProfile | None,
+    call_type: str,
+    default: str,
+) -> str:
+    """Resolve which model to use based on precedence.
+
+    Priority order:
+    1. Explicit model parameter
+    2. Profile-based model
+    3. Default from global settings
+
+    Args:
+        model: Explicitly provided model string
+        profile: ModelProfile for this task
+        call_type: Type of call ("fast", "reasoning", "research")
+        default: Default model if nothing else specified
+
+    Returns:
+        Model identifier string
+    """
+    if model:
+        return model
+
+    if profile:
+        model_map = {
+            "fast": profile.fast,
+            "reasoning": profile.reasoning,
+            "research": profile.research,
+        }
+        return model_map.get(call_type, default)
+
+    return default
+
+
+def _build_json_schema_response_format(
+    schema: dict,
+    schema_name: str,
+) -> dict[str, Any]:
+    """Build response_format for JSON schema structured output.
+
+    Args:
+        schema: JSON schema dictionary
+        schema_name: Name for the schema
+
+    Returns:
+        response_format dictionary
+    """
+    return {
+        "type": "json_schema",
+        "json_schema": {
+            "name": schema_name,
+            "strict": True,
+            "schema": schema,
+        },
+    }
 
 
 def simple_call(
     prompt: str,
     response_schema: dict,
     schema_name: str = "response",
-    model: str = "gpt-5-mini",
+    model: str | None = None,
+    profile: ModelProfile | None = None,
     log: bool = True,
 ) -> dict:
     """
@@ -82,42 +140,51 @@ def simple_call(
         prompt: The prompt
         response_schema: JSON schema for the response
         schema_name: Name for the schema
-        model: Model to use (gpt-5-mini recommended)
+        model: Explicit model override (e.g., "openai/gpt-4o-mini")
+        profile: ModelProfile to use (uses profile.fast if no explicit model)
         log: Whether to log request/response to file
 
     Returns:
         Structured data matching the schema
+
+    Example:
+        # Using explicit model (backward compatible)
+        simple_call(prompt, schema, model="openai/gpt-4o-mini")
+
+        # Using profile
+        simple_call(prompt, schema, profile=profiles.population)
     """
-    client = get_openai_client()
+    settings = get_settings()
+    resolved_model = _resolve_model(
+        model=model,
+        profile=profile,
+        call_type="fast",
+        default=settings.default_fast_model,
+    )
+
+    client = get_openrouter_client()
+
+    messages = [{"role": "user", "content": prompt}]
+    response_format = _build_json_schema_response_format(response_schema, schema_name)
 
     request_params = {
-        "model": model,
-        "input": prompt,
-        "text": {
-            "format": {
-                "type": "json_schema",
-                "name": schema_name,
-                "strict": True,
-                "schema": response_schema,
-            }
-        },
+        "model": resolved_model,
+        "messages": messages,
+        "response_format": response_format,
     }
 
-    response = client.responses.create(**request_params)
+    response = client.chat_completion(**request_params)
 
-    # Extract structured data
+    # Extract structured data from response
     structured_data = None
-    for item in response.output:
-        if hasattr(item, "type") and item.type == "message":
-            for content_item in item.content:
-                if hasattr(content_item, "type") and content_item.type == "output_text":
-                    if hasattr(content_item, "text"):
-                        structured_data = json.loads(content_item.text)
+    if response.choices and response.choices[0].message.content:
+        content = response.choices[0].message.content
+        structured_data = json.loads(content)
 
     if log:
         _log_request_response(
             function_name="simple_call",
-            request=request_params,
+            request={**request_params, "resolved_model": resolved_model},
             response=response,
         )
 
@@ -128,12 +195,13 @@ def reasoning_call(
     prompt: str,
     response_schema: dict,
     schema_name: str = "response",
-    model: str = "gpt-5",
-    reasoning_effort: str = "low",
+    model: str | None = None,
+    profile: ModelProfile | None = None,
+    reasoning_effort: str | None = None,
     log: bool = True,
 ) -> dict:
     """
-    GPT-5 with reasoning and structured output, but NO web search.
+    LLM call with reasoning and structured output, but NO web search.
 
     Use this for tasks that require reasoning but not external data:
     - Attribute selection/categorization
@@ -144,44 +212,72 @@ def reasoning_call(
         prompt: What to reason about
         response_schema: JSON schema for the response
         schema_name: Name for the schema
-        model: Model to use (gpt-5, gpt-5.1, etc.)
-        reasoning_effort: "low", "medium", or "high"
+        model: Explicit model override (e.g., "anthropic/claude-sonnet-4")
+        profile: ModelProfile to use (uses profile.reasoning if no explicit model)
+        reasoning_effort: Override reasoning effort ("low", "medium", "high")
         log: Whether to log request/response to file
 
     Returns:
         Structured data matching the schema
-    """
-    client = get_openai_client()
 
-    request_params = {
-        "model": model,
-        "reasoning": {"effort": reasoning_effort},
-        "input": [{"role": "user", "content": prompt}],
-        "text": {
-            "format": {
-                "type": "json_schema",
-                "name": schema_name,
-                "strict": True,
-                "schema": response_schema,
-            }
-        },
+    Example:
+        # Using explicit model (backward compatible)
+        reasoning_call(prompt, schema, model="anthropic/claude-sonnet-4")
+
+        # Using profile
+        reasoning_call(prompt, schema, profile=profiles.population)
+    """
+    settings = get_settings()
+    resolved_model = _resolve_model(
+        model=model,
+        profile=profile,
+        call_type="reasoning",
+        default=settings.default_reasoning_model,
+    )
+
+    # Resolve reasoning effort
+    effort = reasoning_effort or (profile.reasoning_effort if profile else "low")
+
+    client = get_openrouter_client()
+
+    # Build system message to encourage structured reasoning
+    system_message = (
+        "You are an expert analyst. Think through this problem step by step, "
+        "then provide your answer in the requested JSON format."
+    )
+
+    messages = [
+        {"role": "system", "content": system_message},
+        {"role": "user", "content": prompt},
+    ]
+    response_format = _build_json_schema_response_format(response_schema, schema_name)
+
+    request_params: dict[str, Any] = {
+        "model": resolved_model,
+        "messages": messages,
+        "response_format": response_format,
     }
 
-    response = client.responses.create(**request_params)
+    # Add provider-specific reasoning parameters
+    reasoning_params = client.get_reasoning_params(resolved_model, effort)
+    request_params.update(reasoning_params)
 
-    # Extract structured data
+    response = client.chat_completion(**request_params)
+
+    # Extract structured data from response
     structured_data = None
-    for item in response.output:
-        if hasattr(item, "type") and item.type == "message":
-            for content_item in item.content:
-                if hasattr(content_item, "type") and content_item.type == "output_text":
-                    if hasattr(content_item, "text"):
-                        structured_data = json.loads(content_item.text)
+    if response.choices and response.choices[0].message.content:
+        content = response.choices[0].message.content
+        structured_data = json.loads(content)
 
     if log:
         _log_request_response(
             function_name="reasoning_call",
-            request=request_params,
+            request={
+                **request_params,
+                "resolved_model": resolved_model,
+                "reasoning_effort": effort,
+            },
             response=response,
         )
 
@@ -192,8 +288,9 @@ def agentic_research(
     prompt: str,
     response_schema: dict,
     schema_name: str = "research_data",
-    model: str = "gpt-5",
-    reasoning_effort: str = "low",
+    model: str | None = None,
+    profile: ModelProfile | None = None,
+    reasoning_effort: str | None = None,
     log: bool = True,
 ) -> tuple[dict, list[str]]:
     """
@@ -205,24 +302,71 @@ def agentic_research(
     3. Reason about the results
     4. Return structured data matching the schema
 
+    Note: Web search is currently best supported by OpenAI models.
+    For other providers, consider using a research model or
+    providing context directly.
+
     Args:
         prompt: What to research
         response_schema: JSON schema for the response
         schema_name: Name for the schema
-        model: Model to use (gpt-5, gpt-5.1, etc.)
-        reasoning_effort: "low", "medium", or "high"
+        model: Explicit model override (e.g., "openai/gpt-4o")
+        profile: ModelProfile to use (uses profile.research if no explicit model)
+        reasoning_effort: Override reasoning effort ("low", "medium", "high")
         log: Whether to log request/response to file
 
     Returns:
         Tuple of (structured_data, source_urls)
+
+    Example:
+        # Using explicit model (backward compatible)
+        data, sources = agentic_research(prompt, schema, model="openai/gpt-4o")
+
+        # Using profile
+        data, sources = agentic_research(prompt, schema, profile=profiles.population)
     """
-    client = get_openai_client()
+    settings = get_settings()
+    resolved_model = _resolve_model(
+        model=model,
+        profile=profile,
+        call_type="research",
+        default=settings.default_research_model,
+    )
+
+    # Resolve reasoning effort
+    effort = reasoning_effort or (profile.reasoning_effort if profile else "low")
+
+    client = get_openrouter_client()
+
+    # Check if model supports web search
+    if not client.supports_web_search(resolved_model):
+        # For models without web search, we do a reasoning call
+        # and return empty sources
+        # Future: Could integrate alternative search tools
+        result = reasoning_call(
+            prompt=prompt,
+            response_schema=response_schema,
+            schema_name=schema_name,
+            model=resolved_model,
+            reasoning_effort=effort,
+            log=log,
+        )
+        return result, []
+
+    # For OpenAI models with web search support, we use the responses API
+    # via the underlying OpenAI client
+    from openai import OpenAI
+
+    # Create a direct OpenAI client for responses API
+    openai_client = OpenAI(
+        api_key=settings.openrouter_api_key,
+        base_url="https://openrouter.ai/api/v1",
+    )
 
     request_params = {
-        "model": model,
+        "model": resolved_model,
         "input": prompt,
-        "tools": [{"type": "web_search"}],
-        "reasoning": {"effort": reasoning_effort},
+        "tools": [{"type": "web_search_preview"}],
         "text": {
             "format": {
                 "type": "json_schema",
@@ -231,52 +375,81 @@ def agentic_research(
                 "schema": response_schema,
             }
         },
-        "include": ["web_search_call.action.sources"],
     }
 
-    response = client.responses.create(**request_params)
+    # Try responses API first (for web search support)
+    try:
+        response = openai_client.responses.create(**request_params)
 
-    # Extract structured data and sources
-    structured_data = None
-    sources = []
+        # Extract structured data and sources
+        structured_data = None
+        sources = []
 
-    for item in response.output:
-        # Check for web search results - sources are here
-        if hasattr(item, "type") and item.type == "web_search_call":
-            if hasattr(item, "action") and item.action:
-                if hasattr(item.action, "sources") and item.action.sources:
-                    for source in item.action.sources:
-                        # Handle both dict and object access
-                        if isinstance(source, dict):
-                            if "url" in source:
-                                sources.append(source["url"])
-                        elif hasattr(source, "url"):
-                            sources.append(source.url)
+        for item in response.output:
+            # Check for web search results - sources are here
+            if hasattr(item, "type") and item.type == "web_search_call":
+                if hasattr(item, "action") and item.action:
+                    if hasattr(item.action, "sources") and item.action.sources:
+                        for source in item.action.sources:
+                            if isinstance(source, dict):
+                                if "url" in source:
+                                    sources.append(source["url"])
+                            elif hasattr(source, "url"):
+                                sources.append(source.url)
 
-        # Check message content
-        if hasattr(item, "type") and item.type == "message":
-            for content_item in item.content:
-                if hasattr(content_item, "type") and content_item.type == "output_text":
-                    if hasattr(content_item, "text"):
-                        structured_data = json.loads(content_item.text)
-                    if (
-                        hasattr(content_item, "annotations")
-                        and content_item.annotations
-                    ):
-                        for annotation in content_item.annotations:
-                            if (
-                                hasattr(annotation, "type")
-                                and annotation.type == "url_citation"
-                            ):
-                                if hasattr(annotation, "url"):
-                                    sources.append(annotation.url)
+            # Check message content
+            if hasattr(item, "type") and item.type == "message":
+                for content_item in item.content:
+                    if hasattr(content_item, "type") and content_item.type == "output_text":
+                        if hasattr(content_item, "text"):
+                            structured_data = json.loads(content_item.text)
+                        if hasattr(content_item, "annotations") and content_item.annotations:
+                            for annotation in content_item.annotations:
+                                if hasattr(annotation, "type") and annotation.type == "url_citation":
+                                    if hasattr(annotation, "url"):
+                                        sources.append(annotation.url)
 
-    if log:
-        _log_request_response(
-            function_name="agentic_research",
-            request=request_params,
-            response=response,
-            sources=list(set(sources)),
+        if log:
+            _log_request_response(
+                function_name="agentic_research",
+                request={
+                    **request_params,
+                    "resolved_model": resolved_model,
+                    "reasoning_effort": effort,
+                },
+                response=response,
+                sources=list(set(sources)),
+            )
+
+        return structured_data or {}, list(set(sources))
+
+    except Exception as e:
+        # Fall back to regular chat completion if responses API fails
+        if log:
+            print(f"  [Responses API failed, falling back to chat: {e}]")
+
+        result = reasoning_call(
+            prompt=f"Research the following and provide accurate information:\n\n{prompt}",
+            response_schema=response_schema,
+            schema_name=schema_name,
+            model=resolved_model,
+            reasoning_effort=effort,
+            log=log,
         )
+        return result, []
 
-    return structured_data or {}, list(set(sources))
+
+# =============================================================================
+# Backward Compatibility
+# =============================================================================
+
+
+def get_openai_client():
+    """Legacy function for backward compatibility.
+
+    Returns the OpenRouter client's underlying OpenAI client.
+
+    Deprecated:
+        Use get_openrouter_client() instead.
+    """
+    return get_openrouter_client().client

--- a/entropy/core/providers.py
+++ b/entropy/core/providers.py
@@ -1,0 +1,173 @@
+"""OpenRouter client wrapper with provider-agnostic interface.
+
+Provides a unified interface for accessing various LLM providers through
+OpenRouter's API, which is compatible with the OpenAI client library.
+"""
+
+from functools import lru_cache
+from typing import Any
+
+from openai import OpenAI
+
+from ..config import get_settings
+
+
+class OpenRouterClient:
+    """OpenRouter API client wrapper.
+
+    Uses the OpenAI client library with OpenRouter's base URL.
+    Handles provider-specific quirks and structured output differences.
+    """
+
+    BASE_URL = "https://openrouter.ai/api/v1"
+
+    def __init__(self, api_key: str | None = None):
+        """Initialize OpenRouter client.
+
+        Args:
+            api_key: OpenRouter API key. If not provided, uses settings.
+        """
+        settings = get_settings()
+        self._api_key = api_key or settings.openrouter_api_key
+
+        if not self._api_key:
+            raise ValueError(
+                "OpenRouter API key is required. Set OPENROUTER_API_KEY in .env"
+            )
+
+        self._client = OpenAI(
+            api_key=self._api_key,
+            base_url=self.BASE_URL,
+        )
+
+    @property
+    def client(self) -> OpenAI:
+        """Get the underlying OpenAI client."""
+        return self._client
+
+    def chat_completion(
+        self,
+        messages: list[dict[str, Any]],
+        model: str,
+        response_format: dict[str, Any] | None = None,
+        tools: list[dict[str, Any]] | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Create a chat completion.
+
+        Args:
+            messages: Chat messages
+            model: Model identifier (e.g., "openai/gpt-4o-mini")
+            response_format: Optional response format specification
+            tools: Optional tool definitions
+            **kwargs: Additional parameters passed to the API
+
+        Returns:
+            Chat completion response
+        """
+        params: dict[str, Any] = {
+            "model": model,
+            "messages": messages,
+            **kwargs,
+        }
+
+        if response_format:
+            params["response_format"] = response_format
+
+        if tools:
+            params["tools"] = tools
+
+        return self._client.chat.completions.create(**params)
+
+    def is_openai_model(self, model: str) -> bool:
+        """Check if a model is an OpenAI model.
+
+        Args:
+            model: Model identifier
+
+        Returns:
+            True if this is an OpenAI model
+        """
+        return model.startswith("openai/")
+
+    def is_anthropic_model(self, model: str) -> bool:
+        """Check if a model is an Anthropic model.
+
+        Args:
+            model: Model identifier
+
+        Returns:
+            True if this is an Anthropic model
+        """
+        return model.startswith("anthropic/")
+
+    def supports_structured_output(self, model: str) -> bool:
+        """Check if a model supports JSON schema structured output.
+
+        Some models support response_format with JSON schema,
+        others may need prompting or other approaches.
+
+        Args:
+            model: Model identifier
+
+        Returns:
+            True if model supports structured JSON output
+        """
+        # Most modern models support JSON mode at minimum
+        # OpenAI models support full JSON schema
+        # Anthropic models support structured output via their API
+        supported_prefixes = (
+            "openai/gpt-4",
+            "openai/gpt-3.5",
+            "anthropic/claude",
+            "google/gemini",
+            "meta-llama/llama-3",
+        )
+        return any(model.startswith(prefix) for prefix in supported_prefixes)
+
+    def supports_web_search(self, model: str) -> bool:
+        """Check if a model supports web search tools.
+
+        Currently, only OpenAI models via OpenRouter support
+        the web_search tool that the Responses API uses.
+        For other providers, we may need alternative approaches.
+
+        Args:
+            model: Model identifier
+
+        Returns:
+            True if model supports web search
+        """
+        # OpenAI models support web search through OpenRouter
+        return model.startswith("openai/")
+
+    def get_reasoning_params(self, model: str, effort: str) -> dict[str, Any]:
+        """Get provider-specific reasoning parameters.
+
+        Different providers have different ways of enabling reasoning/thinking.
+        This method returns the appropriate parameters for each provider.
+
+        Args:
+            model: Model identifier
+            effort: Reasoning effort level ("low", "medium", "high")
+
+        Returns:
+            Dictionary of provider-specific parameters for reasoning
+        """
+        # OpenAI models (o1, etc.) use reasoning parameter
+        if model.startswith("openai/o"):
+            return {"reasoning": {"effort": effort}}
+
+        # For other models, we might use different parameters
+        # or include reasoning instructions in the prompt
+        return {}
+
+
+@lru_cache(maxsize=1)
+def get_openrouter_client() -> OpenRouterClient:
+    """Get cached OpenRouter client instance.
+
+    Returns:
+        Cached OpenRouterClient instance
+    """
+    return OpenRouterClient()

--- a/entropy/population/architect/selector.py
+++ b/entropy/population/architect/selector.py
@@ -7,6 +7,7 @@ Discovers all relevant attributes for a population across four categories:
 - Personality: Behavioral/psychological traits when relevant
 """
 
+from ...config import ModelProfile
 from ...core.llm import reasoning_call
 from ...core.models import AttributeSpec, DiscoveredAttribute
 
@@ -77,13 +78,14 @@ def select_attributes(
     size: int,
     geography: str | None = None,
     context: list[AttributeSpec] | None = None,
-    model: str = "gpt-5",
-    reasoning_effort: str = "low",
+    model: str | None = None,
+    profile: ModelProfile | None = None,
+    reasoning_effort: str | None = None,
 ) -> list[DiscoveredAttribute]:
     """
     Discover all relevant attributes for a population.
 
-    Uses GPT-5 with reasoning to analyze the population and identify
+    Uses LLM with reasoning to analyze the population and identify
     attributes across all applicable categories. The model considers:
     - What makes this population unique
     - Geographic/cultural context
@@ -98,8 +100,9 @@ def select_attributes(
         size: Number of agents (for context)
         geography: Geographic scope if known
         context: Existing attributes from base population (for overlay mode)
-        model: Model to use
-        reasoning_effort: "low", "medium", or "high"
+        model: Explicit model override (e.g., "anthropic/claude-sonnet-4")
+        profile: ModelProfile to use (uses profile.reasoning if no explicit model)
+        reasoning_effort: Override reasoning effort ("low", "medium", "high")
 
     Returns:
         List of DiscoveredAttribute objects
@@ -258,6 +261,7 @@ For each attribute:
         response_schema=ATTRIBUTE_SELECTION_SCHEMA,
         schema_name="attribute_selection",
         model=model,
+        profile=profile,
         reasoning_effort=reasoning_effort,
     )
 

--- a/entropy/population/architect/sufficiency.py
+++ b/entropy/population/architect/sufficiency.py
@@ -4,6 +4,7 @@ Verifies that the population description has enough information
 to proceed with attribute discovery and spec generation.
 """
 
+from ...config import ModelProfile
 from ...core.llm import simple_call
 from ...core.models import SufficiencyResult
 
@@ -38,7 +39,8 @@ SUFFICIENCY_SCHEMA = {
 def check_sufficiency(
     description: str,
     default_size: int = 1000,
-    model: str = "gpt-5-mini",
+    model: str | None = None,
+    profile: ModelProfile | None = None,
 ) -> SufficiencyResult:
     """
     Check if a population description is sufficient for spec generation.
@@ -51,7 +53,8 @@ def check_sufficiency(
     Args:
         description: Natural language population description
         default_size: Default size if not specified
-        model: Model to use (gpt-5-mini recommended for speed)
+        model: Explicit model override (e.g., "openai/gpt-4o-mini")
+        profile: ModelProfile to use (uses profile.fast if no explicit model)
 
     Returns:
         SufficiencyResult with sufficient flag, size, and any clarifications needed
@@ -92,6 +95,7 @@ Be lenient - if you can reasonably infer a specific population, mark as sufficie
         response_schema=SUFFICIENCY_SCHEMA,
         schema_name="sufficiency_check",
         model=model,
+        profile=profile,
     )
 
     return SufficiencyResult(

--- a/entropy/simulation/reasoning.py
+++ b/entropy/simulation/reasoning.py
@@ -7,6 +7,7 @@ and form opinions using structured LLM calls.
 import logging
 from typing import Any
 
+from ..config import ModelProfile
 from ..core.llm import simple_call
 from ..core.models import (
     ScenarioSpec,
@@ -188,6 +189,7 @@ def reason_agent(
     context: ReasoningContext,
     scenario: ScenarioSpec,
     config: SimulationRunConfig,
+    profile: ModelProfile | None = None,
 ) -> ReasoningResponse | None:
     """Call LLM to get agent's reasoning and response.
 
@@ -195,6 +197,7 @@ def reason_agent(
         context: Reasoning context with persona, event, exposures
         scenario: Scenario specification
         config: Simulation run configuration
+        profile: ModelProfile to use (uses profile.fast if no model in config)
 
     Returns:
         ReasoningResponse with extracted outcomes, or None if failed
@@ -210,7 +213,8 @@ def reason_agent(
                 prompt=prompt,
                 response_schema=schema,
                 schema_name="agent_response",
-                model=config.model,
+                model=config.model if config.model else None,
+                profile=profile,
                 log=True,
             )
 
@@ -260,6 +264,7 @@ def batch_reason_agents(
     contexts: list[ReasoningContext],
     scenario: ScenarioSpec,
     config: SimulationRunConfig,
+    profile: ModelProfile | None = None,
 ) -> list[tuple[str, ReasoningResponse | None]]:
     """Reason multiple agents (sequentially for now).
 
@@ -269,6 +274,7 @@ def batch_reason_agents(
         contexts: List of reasoning contexts
         scenario: Scenario specification
         config: Simulation run configuration
+        profile: ModelProfile to use for reasoning calls
 
     Returns:
         List of (agent_id, response) tuples
@@ -276,7 +282,7 @@ def batch_reason_agents(
     results = []
 
     for context in contexts:
-        response = reason_agent(context, scenario, config)
+        response = reason_agent(context, scenario, config, profile=profile)
         results.append((context.agent_id, response))
 
     return results


### PR DESCRIPTION
This commit refactors the LLM client to use OpenRouter as the primary provider. It also introduces a new ModelProfile system for managing LLM configurations across different phases and tasks. This provides a more flexible and robust way to handle LLM interactions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Modernizes LLM integration and centralizes model selection.
> 
> - Adds `OpenRouterClient` wrapper and refactors `simple_call`, `reasoning_call`, `agentic_research` to use OpenRouter chat completions; supports JSON-schema `response_format` and web search via Responses API fallback
> - Introduces `ModelProfile`, `PhaseProfiles`, `get_profile`, and expanded `Settings` to support env-driven defaults and phase overrides (`DEFAULT_*_MODEL`, `POPULATION_*`, `SCENARIO_*`, `SIMULATION_*`)
> - Updates `.env.example` to use `OPENROUTER_API_KEY` and new model default/override vars; keeps legacy `OPENAI_API_KEY` for compatibility
> - Propagates optional `model`/`profile` parameters across population steps (`sufficiency`, `selector`, `hydrator`) and simulation reasoning; retains `get_openai_client()` shim for backward compatibility
> - Maintains structured logging of requests/responses to `/logs`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0b852d5da5dd4aee28420c3ead4d801fee3e1e97. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->