### PR TITLE
Align scenario prompts with CAPABILITIES.md philosophy

### DIFF
--- a/entropy/scenario/exposure.py
+++ b/entropy/scenario/exposure.py
@@ -226,6 +226,8 @@ Consider how this event would realistically reach this population:
 3. **Rumors:**
    - Start with small group (low probability, t=0)
    - Spread organically (t=1+)
+   - Rumors thrive on **ambiguity**—target agents in "epistemic bubbles" who lack access to authoritative sources
+   - For rumors, consider how 'low trust' or 'high anxiety' groups might be exposed first (e.g., when: "institutional_trust < 0.4" or "anxiety > 0.6")
 
 4. **Policy Changes:**
    - Official channels (t=0)

--- a/entropy/scenario/interaction.py
+++ b/entropy/scenario/interaction.py
@@ -237,6 +237,7 @@ Examples:
 - {{"when": "extraversion > 0.7", "multiply": 1.3, "add": 0}}
 - {{"when": "age < 30", "multiply": 1.5, "add": 0}}
 - {{"when": "edge_type == 'colleague'", "multiply": 1.5, "add": 0}} (use actual edge types from network)
+- {{"when": "institutional_trust < 0.3", "multiply": 2.0, "add": 0}} (psychographic: low-trust agents amplify rumors)
 
 ### decay_per_hop (0-1)
 How much information fidelity is lost each time it's passed on.

--- a/entropy/scenario/outcomes.py
+++ b/entropy/scenario/outcomes.py
@@ -164,6 +164,12 @@ Free-form text responses.
 | Technology adoption | adoption_willingness, trust_level, information_seeking |
 | Emergency/Crisis | urgency_perception, compliance, information_sharing |
 | Rumor/News | belief_level, verification_behavior, share_intent |
+| Professional Alignment | exit_intent, voice_intent, compliance_level, burnout_impact |
+| Information Warfare | belief_level, amplification_intent, source_skepticism, narrative_alignment |
+
+## Reasoning Capture
+
+**IMPORTANT:** Ensure outcomes capture the **reasoning** behind decisions, not just the decision itself. This enables post-hoc discovery of emergent behaviors. For example, agents might be "rotating subscriptions" rather than just "cancelling"—a nuance only visible when reasoning is captured.
 
 ## Guidelines
 

--- a/entropy/scenario/parser.py
+++ b/entropy/scenario/parser.py
@@ -129,7 +129,7 @@ Parse the following scenario description into a structured event definition.
 Choose the most appropriate event type:
 
 1. **announcement**: Official communication from an organization/authority
-   - Examples: company policy changes, official statements, product updates
+   - Examples: government mandates, public health guidance, platform-wide service changes
    - High credibility if from known entity
 
 2. **news**: Information reported by media/journalists
@@ -141,11 +141,11 @@ Choose the most appropriate event type:
    - Low credibility, high ambiguity
 
 4. **policy_change**: Changes to rules, regulations, or laws
-   - Examples: new government regulations, company policy updates
+   - Examples: legislation, regulatory shifts, professional board certification changes
    - High credibility if from authority
 
-5. **product_launch**: Introduction of new product/service/feature
-   - Examples: new app feature, new product line, service expansion
+5. **product_launch**: Market-wide innovation or introduction of transformative product/service
+   - Examples: med-tech firm launches AI diagnostic tool, autonomous vehicle rollout, breakthrough treatment approval
    - High credibility from official source
 
 6. **emergency**: Urgent, time-sensitive information


### PR DESCRIPTION
Update LLM prompts in entropy/scenario to reflect the new architectural focus on Targeted Synthetic Populations and General Population simulations:

- parser.py: Update event type examples (announcement, policy_change, product_launch) to reference public-facing scenarios like government mandates, legislation, and market-wide innovations

- exposure.py: Add epistemic bubble guidance for rumors, including targeting low-trust and high-anxiety groups

- outcomes.py: Add reasoning capture instruction for emergent behavior discovery, and new outcome patterns for Professional Alignment and Information Warfare scenarios

- interaction.py: Add psychographic share_modifier example targeting agents with low institutional trust

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns scenario LLM prompts with population-focused simulation guidance.
> 
> - Parser: expands event type examples for `announcement`, `policy_change`, and `product_launch` to public/market-wide cases in `parser.py`
> - Exposure: adds rumor guidance targeting agents in epistemic bubbles and low-trust/high-anxiety groups in `exposure.py`
> - Interaction: adds psychographic `share_modifiers` example (`institutional_trust < 0.3`) in `interaction.py`
> - Outcomes: introduces new outcome patterns for `Professional Alignment` and `Information Warfare`, plus a “Reasoning Capture” directive in `outcomes.py`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 94d74122ea78525276d8276118cc49df96c9ae4b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->