### PR TITLE
refactor: consolidate validation pathways into core/models/validation.py

### DIFF
--- a/entropy/core/models/__init__.py
+++ b/entropy/core/models/__init__.py
@@ -39,6 +39,15 @@ from .population import (
     SufficiencyResult,
 )
 
+# Validation models (shared across population and scenario)
+from .validation import (
+    Severity,
+    ValidationIssue,
+    ValidationResult,
+    ValidationError,
+    ValidationWarning,
+)
+
 # Scenario models (Phase 2)
 from .scenario import (
     # Event
@@ -63,10 +72,6 @@ from .scenario import (
     # Scenario
     ScenarioMeta,
     ScenarioSpec,
-    # Validation
-    ValidationError,
-    ValidationWarning,
-    ValidationResult,
 )
 
 # Simulation models (Phase 3)
@@ -143,10 +148,12 @@ __all__ = [
     # Scenario - Spec
     "ScenarioMeta",
     "ScenarioSpec",
-    # Scenario - Validation
+    # Validation (shared)
+    "Severity",
+    "ValidationIssue",
+    "ValidationResult",
     "ValidationError",
     "ValidationWarning",
-    "ValidationResult",
     # Simulation
     "SimulationEventType",
     "ExposureRecord",

--- a/entropy/core/models/scenario.py
+++ b/entropy/core/models/scenario.py
@@ -315,30 +315,7 @@ class ScenarioSpec(BaseModel):
 
 
 # =============================================================================
-# Validation Types
+# Validation Types (imported from validation.py for backwards compatibility)
 # =============================================================================
 
-
-class ValidationError(BaseModel):
-    """A validation error in the scenario spec."""
-
-    category: str = Field(description="Category of error (e.g., 'attribute_reference')")
-    location: str = Field(description="Where the error occurred")
-    message: str = Field(description="Error description")
-    suggestion: str | None = Field(default=None, description="How to fix it")
-
-
-class ValidationWarning(BaseModel):
-    """A validation warning in the scenario spec."""
-
-    category: str = Field(description="Category of warning")
-    location: str = Field(description="Where the warning applies")
-    message: str = Field(description="Warning description")
-
-
-class ValidationResult(BaseModel):
-    """Result of validating a scenario spec."""
-
-    valid: bool = Field(description="Whether the spec is valid (no errors)")
-    errors: list[ValidationError] = Field(default_factory=list)
-    warnings: list[ValidationWarning] = Field(default_factory=list)
+from .validation import ValidationError, ValidationWarning, ValidationResult

--- a/entropy/core/models/validation.py
+++ b/entropy/core/models/validation.py
@@ -1,0 +1,229 @@
+"""Unified validation models for Entropy.
+
+This module provides validation types used across population specs,
+scenario specs, and other validation contexts. All validation in
+Entropy should use these models for consistency.
+
+Classes:
+- Severity: ERROR, WARNING, INFO levels
+- ValidationIssue: A single validation issue with context
+- ValidationResult: Collection of issues with helper methods
+"""
+
+from enum import Enum
+
+from pydantic import BaseModel, Field
+
+
+class Severity(str, Enum):
+    """Severity level for validation issues."""
+
+    ERROR = "error"  # Blocks processing
+    WARNING = "warning"  # Processing continues
+    INFO = "info"  # Informational only
+
+
+class ValidationIssue(BaseModel):
+    """A single validation issue found during validation.
+
+    This unified model supports:
+    - Population spec validation (syntactic/semantic checks)
+    - Scenario spec validation
+    - LLM response validation (fail-fast with retry)
+
+    Attributes:
+        severity: ERROR blocks processing, WARNING/INFO do not
+        category: Issue category (e.g., 'FORMULA_SYNTAX', 'WEIGHT_INVALID')
+        location: Where the issue occurred (attribute name, path, etc.)
+        message: Human-readable description of the issue
+        suggestion: Optional fix suggestion
+        modifier_index: For modifier-specific issues
+        value: The problematic value (useful for LLM retry prompts)
+    """
+
+    severity: Severity = Field(
+        default=Severity.ERROR,
+        description="Issue severity level",
+    )
+    category: str = Field(
+        description="Category of issue (e.g., 'FORMULA_SYNTAX', 'TYPE_MISMATCH')",
+    )
+    location: str = Field(
+        description="Where the issue occurred (attribute name, field path, etc.)",
+    )
+    message: str = Field(
+        description="Human-readable description of the issue",
+    )
+    suggestion: str | None = Field(
+        default=None,
+        description="How to fix the issue",
+    )
+    modifier_index: int | None = Field(
+        default=None,
+        description="Index of the modifier if issue is modifier-specific",
+    )
+    value: str | None = Field(
+        default=None,
+        description="The problematic value (for LLM retry context)",
+    )
+
+    def __str__(self) -> str:
+        """Format as human-readable string."""
+        loc = self.location
+        if self.modifier_index is not None:
+            loc = f"{self.location}[{self.modifier_index}]"
+        return f"{loc}: {self.message}"
+
+    def for_llm_retry(self) -> str:
+        """Format for LLM retry prompt."""
+        lines = [f"ERROR in {self.location}:"]
+        if self.value:
+            lines.append(f"  Value: {repr(self.value)}")
+        lines.append(f"  Problem: {self.message}")
+        if self.suggestion:
+            lines.append(f"  Fix: {self.suggestion}")
+        return "\n".join(lines)
+
+
+class ValidationResult(BaseModel):
+    """Result of validating a spec or LLM response.
+
+    Provides a unified interface for all validation results with
+    helper properties and methods for common operations.
+
+    Example:
+        >>> result = ValidationResult()
+        >>> result.add_error("SYNTAX", "formula", "Invalid Python syntax")
+        >>> result.valid
+        False
+        >>> print(result.format_for_retry())
+        ## VALIDATION ERRORS - PLEASE FIX:
+        ...
+    """
+
+    issues: list[ValidationIssue] = Field(
+        default_factory=list,
+        description="All validation issues found",
+    )
+
+    @property
+    def valid(self) -> bool:
+        """True if no ERROR-level issues."""
+        return not any(i.severity == Severity.ERROR for i in self.issues)
+
+    @property
+    def errors(self) -> list[ValidationIssue]:
+        """All ERROR-level issues."""
+        return [i for i in self.issues if i.severity == Severity.ERROR]
+
+    @property
+    def warnings(self) -> list[ValidationIssue]:
+        """All WARNING-level issues."""
+        return [i for i in self.issues if i.severity == Severity.WARNING]
+
+    @property
+    def info(self) -> list[ValidationIssue]:
+        """All INFO-level issues."""
+        return [i for i in self.issues if i.severity == Severity.INFO]
+
+    def add_error(
+        self,
+        category: str,
+        location: str,
+        message: str,
+        suggestion: str | None = None,
+        modifier_index: int | None = None,
+        value: str | None = None,
+    ) -> None:
+        """Add an ERROR-level issue."""
+        self.issues.append(
+            ValidationIssue(
+                severity=Severity.ERROR,
+                category=category,
+                location=location,
+                message=message,
+                suggestion=suggestion,
+                modifier_index=modifier_index,
+                value=value,
+            )
+        )
+
+    def add_warning(
+        self,
+        category: str,
+        location: str,
+        message: str,
+        suggestion: str | None = None,
+        modifier_index: int | None = None,
+    ) -> None:
+        """Add a WARNING-level issue."""
+        self.issues.append(
+            ValidationIssue(
+                severity=Severity.WARNING,
+                category=category,
+                location=location,
+                message=message,
+                suggestion=suggestion,
+                modifier_index=modifier_index,
+            )
+        )
+
+    def add_info(
+        self,
+        category: str,
+        location: str,
+        message: str,
+    ) -> None:
+        """Add an INFO-level issue."""
+        self.issues.append(
+            ValidationIssue(
+                severity=Severity.INFO,
+                category=category,
+                location=location,
+                message=message,
+            )
+        )
+
+    def format_for_retry(self) -> str:
+        """Format all errors as a retry prompt section for LLM."""
+        if self.valid:
+            return ""
+
+        lines = [
+            "## PREVIOUS ATTEMPT FAILED - PLEASE FIX THESE ERRORS:",
+            "",
+        ]
+        for err in self.errors:
+            lines.append(err.for_llm_retry())
+            lines.append("")
+
+        lines.append("Please regenerate the output with these issues fixed.")
+        lines.append("")
+
+        return "\n".join(lines)
+
+    def __str__(self) -> str:
+        """Human-readable summary."""
+        if self.valid and not self.warnings:
+            return "Validation passed"
+        parts = []
+        if self.errors:
+            parts.append(f"{len(self.errors)} error(s)")
+        if self.warnings:
+            parts.append(f"{len(self.warnings)} warning(s)")
+        return ", ".join(parts)
+
+    def __add__(self, other: "ValidationResult") -> "ValidationResult":
+        """Combine two validation results."""
+        return ValidationResult(issues=self.issues + other.issues)
+
+    def __iadd__(self, other: "ValidationResult") -> "ValidationResult":
+        """In-place combine."""
+        self.issues.extend(other.issues)
+        return self
+
+
+# Backwards compatibility aliases for scenario.py
+# These map the old two-class pattern to the unified model
+ValidationError = ValidationIssue
+ValidationWarning = ValidationIssue

--- a/entropy/population/validator/semantic.py
+++ b/entropy/population/validator/semantic.py
@@ -6,7 +6,7 @@ They help identify potential issues but don't indicate structural problems.
 
 import re
 
-from . import Severity, ValidationIssue
+from ...core.models.validation import Severity, ValidationIssue
 from ...core.models import (
     PopulationSpec,
     AttributeSpec,
@@ -76,7 +76,7 @@ def _check_noop_modifiers(attr: AttributeSpec) -> list[ValidationIssue]:
                 ValidationIssue(
                     severity=Severity.WARNING,
                     category="NO_OP",
-                    attribute=attr.name,
+                    location=attr.name,
                     modifier_index=i,
                     message="modifier has no effect (multiply=1.0, add=0, no overrides)",
                     suggestion="Remove this modifier or add meaningful values",
@@ -164,7 +164,7 @@ def _check_modifier_stacking(attr: AttributeSpec) -> list[ValidationIssue]:
             ValidationIssue(
                 severity=Severity.WARNING,
                 category="MODIFIER_STACKING",
-                attribute=attr.name,
+                location=attr.name,
                 message=f"stacked modifiers could push value to {worst_high:.1f} (hard_max={hard_max})",
                 suggestion="Review modifier values or add clamping logic",
             )
@@ -186,7 +186,7 @@ def _check_modifier_stacking(attr: AttributeSpec) -> list[ValidationIssue]:
             ValidationIssue(
                 severity=Severity.WARNING,
                 category="MODIFIER_STACKING",
-                attribute=attr.name,
+                location=attr.name,
                 message=f"stacked modifiers could push value to {worst_low:.1f} (hard_min={hard_min})",
                 suggestion="Review modifier values or add clamping logic",
             )
@@ -255,7 +255,7 @@ def _check_condition_values(
                                 ValidationIssue(
                                     severity=Severity.WARNING,
                                     category="CONDITION_VALUE",
-                                    attribute=attr.name,
+                                    location=attr.name,
                                     modifier_index=i,
                                     message=f"condition compares {compared_attr} to '{literal}' which is not in its options",
                                     suggestion=f"Valid options for {compared_attr}: {', '.join(sorted(valid_options))}",

--- a/entropy/population/validator/syntactic.py
+++ b/entropy/population/validator/syntactic.py
@@ -7,7 +7,7 @@ All checks are structural - no sampling required.
 import ast
 import re
 
-from . import Severity, ValidationIssue
+from ...core.models.validation import Severity, ValidationIssue
 from ...core.models import (
     PopulationSpec,
     AttributeSpec,
@@ -176,7 +176,7 @@ def _check_type_modifier_compatibility(attr: AttributeSpec) -> list[ValidationIs
                     ValidationIssue(
                         severity=Severity.ERROR,
                         category="TYPE_MISMATCH",
-                        attribute=attr.name,
+                        location=attr.name,
                         modifier_index=i,
                         message="numeric distribution cannot use weight_overrides",
                         suggestion="Use multiply/add instead",
@@ -187,7 +187,7 @@ def _check_type_modifier_compatibility(attr: AttributeSpec) -> list[ValidationIs
                     ValidationIssue(
                         severity=Severity.ERROR,
                         category="TYPE_MISMATCH",
-                        attribute=attr.name,
+                        location=attr.name,
                         modifier_index=i,
                         message="numeric distribution cannot use probability_override",
                         suggestion="Use multiply/add instead",
@@ -200,7 +200,7 @@ def _check_type_modifier_compatibility(attr: AttributeSpec) -> list[ValidationIs
                     ValidationIssue(
                         severity=Severity.ERROR,
                         category="TYPE_MISMATCH",
-                        attribute=attr.name,
+                        location=attr.name,
                         modifier_index=i,
                         message="categorical distribution cannot use multiply",
                         suggestion="Use weight_overrides instead",
@@ -211,7 +211,7 @@ def _check_type_modifier_compatibility(attr: AttributeSpec) -> list[ValidationIs
                     ValidationIssue(
                         severity=Severity.ERROR,
                         category="TYPE_MISMATCH",
-                        attribute=attr.name,
+                        location=attr.name,
                         modifier_index=i,
                         message="categorical distribution cannot use add",
                         suggestion="Use weight_overrides instead",
@@ -222,7 +222,7 @@ def _check_type_modifier_compatibility(attr: AttributeSpec) -> list[ValidationIs
                     ValidationIssue(
                         severity=Severity.ERROR,
                         category="TYPE_MISMATCH",
-                        attribute=attr.name,
+                        location=attr.name,
                         modifier_index=i,
                         message="categorical distribution cannot use probability_override",
                         suggestion="Use weight_overrides instead",
@@ -235,7 +235,7 @@ def _check_type_modifier_compatibility(attr: AttributeSpec) -> list[ValidationIs
                     ValidationIssue(
                         severity=Severity.ERROR,
                         category="TYPE_MISMATCH",
-                        attribute=attr.name,
+                        location=attr.name,
                         modifier_index=i,
                         message="boolean distribution cannot use multiply",
                         suggestion="Use probability_override instead",
@@ -246,7 +246,7 @@ def _check_type_modifier_compatibility(attr: AttributeSpec) -> list[ValidationIs
                     ValidationIssue(
                         severity=Severity.ERROR,
                         category="TYPE_MISMATCH",
-                        attribute=attr.name,
+                        location=attr.name,
                         modifier_index=i,
                         message="boolean distribution cannot use add",
                         suggestion="Use probability_override instead",
@@ -257,7 +257,7 @@ def _check_type_modifier_compatibility(attr: AttributeSpec) -> list[ValidationIs
                     ValidationIssue(
                         severity=Severity.ERROR,
                         category="TYPE_MISMATCH",
-                        attribute=attr.name,
+                        location=attr.name,
                         modifier_index=i,
                         message="boolean distribution cannot use weight_overrides",
                         suggestion="Use probability_override instead",
@@ -288,7 +288,7 @@ def _check_range_violations(attr: AttributeSpec) -> list[ValidationIssue]:
                     ValidationIssue(
                         severity=Severity.ERROR,
                         category="RANGE_VIOLATION",
-                        attribute=attr.name,
+                        location=attr.name,
                         modifier_index=i,
                         message=f"beta distribution add={mod.add} is too large (outputs 0-1 scale)",
                         suggestion="Use small add values (±0.05 to ±0.15) for beta distributions",
@@ -303,7 +303,7 @@ def _check_range_violations(attr: AttributeSpec) -> list[ValidationIssue]:
                         ValidationIssue(
                             severity=Severity.ERROR,
                             category="RANGE_VIOLATION",
-                            attribute=attr.name,
+                            location=attr.name,
                             modifier_index=i,
                             message=f"probability_override={mod.probability_override} must be between 0 and 1",
                         )
@@ -331,7 +331,7 @@ def _check_weight_validity(attr: AttributeSpec) -> list[ValidationIssue]:
             ValidationIssue(
                 severity=Severity.ERROR,
                 category="WEIGHT_INVALID",
-                attribute=attr.name,
+                location=attr.name,
                 message="categorical distribution has no options",
             )
         )
@@ -341,7 +341,7 @@ def _check_weight_validity(attr: AttributeSpec) -> list[ValidationIssue]:
                 ValidationIssue(
                     severity=Severity.ERROR,
                     category="WEIGHT_INVALID",
-                    attribute=attr.name,
+                    location=attr.name,
                     message=f"options ({len(dist.options)}) and weights ({len(dist.weights)}) length mismatch",
                 )
             )
@@ -350,7 +350,7 @@ def _check_weight_validity(attr: AttributeSpec) -> list[ValidationIssue]:
                 ValidationIssue(
                     severity=Severity.ERROR,
                     category="WEIGHT_INVALID",
-                    attribute=attr.name,
+                    location=attr.name,
                     message=f"weights sum to {sum(dist.weights):.2f}, should be ~1.0",
                 )
             )
@@ -367,7 +367,7 @@ def _check_weight_validity(attr: AttributeSpec) -> list[ValidationIssue]:
                         ValidationIssue(
                             severity=Severity.ERROR,
                             category="WEIGHT_INVALID",
-                            attribute=attr.name,
+                            location=attr.name,
                             modifier_index=i,
                             message=f"weight_override key '{key}' not in distribution options",
                             suggestion=f"Valid options: {', '.join(sorted(valid_options))}",
@@ -381,7 +381,7 @@ def _check_weight_validity(attr: AttributeSpec) -> list[ValidationIssue]:
                     ValidationIssue(
                         severity=Severity.ERROR,
                         category="WEIGHT_INVALID",
-                        attribute=attr.name,
+                        location=attr.name,
                         modifier_index=i,
                         message=f"weight_overrides sum to {weight_sum:.2f}, should be ~1.0",
                     )
@@ -394,7 +394,7 @@ def _check_weight_validity(attr: AttributeSpec) -> list[ValidationIssue]:
                     ValidationIssue(
                         severity=Severity.WARNING,
                         category="WEIGHT_INCOMPLETE",
-                        attribute=attr.name,
+                        location=attr.name,
                         modifier_index=i,
                         message=f"weight_overrides missing options: {', '.join(sorted(missing))}",
                     )
@@ -422,7 +422,7 @@ def _check_distribution_params(attr: AttributeSpec) -> list[ValidationIssue]:
                 ValidationIssue(
                     severity=Severity.ERROR,
                     category="DIST_PARAM_INVALID",
-                    attribute=attr.name,
+                    location=attr.name,
                     message=f"std ({dist.std}) cannot be negative",
                 )
             )
@@ -431,7 +431,7 @@ def _check_distribution_params(attr: AttributeSpec) -> list[ValidationIssue]:
                 ValidationIssue(
                     severity=Severity.ERROR,
                     category="DIST_PARAM_INVALID",
-                    attribute=attr.name,
+                    location=attr.name,
                     message="std is 0 (no variance) - use derived strategy instead",
                 )
             )
@@ -440,7 +440,7 @@ def _check_distribution_params(attr: AttributeSpec) -> list[ValidationIssue]:
                 ValidationIssue(
                     severity=Severity.ERROR,
                     category="DIST_PARAM_INVALID",
-                    attribute=attr.name,
+                    location=attr.name,
                     message=f"min ({dist.min}) >= max ({dist.max})",
                 )
             )
@@ -451,7 +451,7 @@ def _check_distribution_params(attr: AttributeSpec) -> list[ValidationIssue]:
                 ValidationIssue(
                     severity=Severity.ERROR,
                     category="DIST_PARAM_INVALID",
-                    attribute=attr.name,
+                    location=attr.name,
                     message="beta distribution alpha must be positive",
                 )
             )
@@ -460,7 +460,7 @@ def _check_distribution_params(attr: AttributeSpec) -> list[ValidationIssue]:
                 ValidationIssue(
                     severity=Severity.ERROR,
                     category="DIST_PARAM_INVALID",
-                    attribute=attr.name,
+                    location=attr.name,
                     message="beta distribution beta must be positive",
                 )
             )
@@ -471,7 +471,7 @@ def _check_distribution_params(attr: AttributeSpec) -> list[ValidationIssue]:
                 ValidationIssue(
                     severity=Severity.ERROR,
                     category="DIST_PARAM_INVALID",
-                    attribute=attr.name,
+                    location=attr.name,
                     message=f"min ({dist.min}) >= max ({dist.max})",
                 )
             )
@@ -483,7 +483,7 @@ def _check_distribution_params(attr: AttributeSpec) -> list[ValidationIssue]:
                     ValidationIssue(
                         severity=Severity.ERROR,
                         category="DIST_PARAM_INVALID",
-                        attribute=attr.name,
+                        location=attr.name,
                         message=f"probability_true ({dist.probability_true}) must be between 0 and 1",
                     )
                 )
@@ -510,7 +510,7 @@ def _check_dependencies(
                 ValidationIssue(
                     severity=Severity.ERROR,
                     category="DEPENDENCY_INVALID",
-                    attribute=attr.name,
+                    location=attr.name,
                     message=f"depends_on references non-existent attribute '{dep}'",
                 )
             )
@@ -535,7 +535,7 @@ def _check_sampling_order(
             ValidationIssue(
                 severity=Severity.ERROR,
                 category="SAMPLING_ORDER_INVALID",
-                attribute=name,
+                location=name,
                 message="attribute missing from sampling_order",
             )
         )
@@ -553,7 +553,7 @@ def _check_sampling_order(
                     ValidationIssue(
                         severity=Severity.ERROR,
                         category="SAMPLING_ORDER_INVALID",
-                        attribute=attr.name,
+                        location=attr.name,
                         message=f"sampled before dependency '{dep}' (positions {attr_idx} vs {dep_idx})",
                     )
                 )
@@ -582,7 +582,7 @@ def _check_conditions(attr: AttributeSpec) -> list[ValidationIssue]:
                 ValidationIssue(
                     severity=Severity.ERROR,
                     category="CONDITION_SYNTAX",
-                    attribute=attr.name,
+                    location=attr.name,
                     modifier_index=i,
                     message=f"invalid condition syntax: {e}",
                 )
@@ -599,7 +599,7 @@ def _check_conditions(attr: AttributeSpec) -> list[ValidationIssue]:
                     ValidationIssue(
                         severity=Severity.ERROR,
                         category="CONDITION_REFERENCE",
-                        attribute=attr.name,
+                        location=attr.name,
                         modifier_index=i,
                         message=f"condition references '{name}' not in depends_on",
                         suggestion=f"Add '{name}' to depends_on or remove from condition",
@@ -628,7 +628,7 @@ def _check_formulas(attr: AttributeSpec) -> list[ValidationIssue]:
                 ValidationIssue(
                     severity=Severity.ERROR,
                     category="FORMULA_SYNTAX",
-                    attribute=attr.name,
+                    location=attr.name,
                     message=f"invalid formula syntax: {e}",
                 )
             )
@@ -640,7 +640,7 @@ def _check_formulas(attr: AttributeSpec) -> list[ValidationIssue]:
                         ValidationIssue(
                             severity=Severity.ERROR,
                             category="FORMULA_REFERENCE",
-                            attribute=attr.name,
+                            location=attr.name,
                             message=f"formula references '{name}' not in depends_on",
                         )
                     )
@@ -658,7 +658,7 @@ def _check_formulas(attr: AttributeSpec) -> list[ValidationIssue]:
                 ValidationIssue(
                     severity=Severity.ERROR,
                     category="FORMULA_SYNTAX",
-                    attribute=attr.name,
+                    location=attr.name,
                     message=f"invalid mean_formula syntax: {e}",
                 )
             )
@@ -670,7 +670,7 @@ def _check_formulas(attr: AttributeSpec) -> list[ValidationIssue]:
                         ValidationIssue(
                             severity=Severity.ERROR,
                             category="FORMULA_REFERENCE",
-                            attribute=attr.name,
+                            location=attr.name,
                             message=f"mean_formula references '{name}' not in depends_on",
                         )
                     )
@@ -694,7 +694,7 @@ def _check_duplicates(attributes: list[AttributeSpec]) -> list[ValidationIssue]:
                 ValidationIssue(
                     severity=Severity.ERROR,
                     category="DUPLICATE",
-                    attribute=attr.name,
+                    location=attr.name,
                     message="duplicate attribute name",
                 )
             )
@@ -723,7 +723,7 @@ def _check_strategy_consistency(attr: AttributeSpec) -> list[ValidationIssue]:
                 ValidationIssue(
                     severity=Severity.ERROR,
                     category="STRATEGY_INVALID",
-                    attribute=attr.name,
+                    location=attr.name,
                     message="independent strategy requires distribution",
                 )
             )
@@ -732,7 +732,7 @@ def _check_strategy_consistency(attr: AttributeSpec) -> list[ValidationIssue]:
                 ValidationIssue(
                     severity=Severity.WARNING,
                     category="STRATEGY_INCONSISTENT",
-                    attribute=attr.name,
+                    location=attr.name,
                     message="independent strategy has formula (will be ignored)",
                 )
             )
@@ -741,7 +741,7 @@ def _check_strategy_consistency(attr: AttributeSpec) -> list[ValidationIssue]:
                 ValidationIssue(
                     severity=Severity.ERROR,
                     category="STRATEGY_INVALID",
-                    attribute=attr.name,
+                    location=attr.name,
                     message="independent strategy cannot have modifiers",
                 )
             )
@@ -750,7 +750,7 @@ def _check_strategy_consistency(attr: AttributeSpec) -> list[ValidationIssue]:
                 ValidationIssue(
                     severity=Severity.ERROR,
                     category="STRATEGY_INVALID",
-                    attribute=attr.name,
+                    location=attr.name,
                     message="independent strategy cannot have depends_on",
                 )
             )
@@ -761,7 +761,7 @@ def _check_strategy_consistency(attr: AttributeSpec) -> list[ValidationIssue]:
                 ValidationIssue(
                     severity=Severity.ERROR,
                     category="STRATEGY_INVALID",
-                    attribute=attr.name,
+                    location=attr.name,
                     message="derived strategy requires formula",
                 )
             )
@@ -770,7 +770,7 @@ def _check_strategy_consistency(attr: AttributeSpec) -> list[ValidationIssue]:
                 ValidationIssue(
                     severity=Severity.ERROR,
                     category="STRATEGY_INVALID",
-                    attribute=attr.name,
+                    location=attr.name,
                     message="derived strategy requires depends_on",
                 )
             )
@@ -779,7 +779,7 @@ def _check_strategy_consistency(attr: AttributeSpec) -> list[ValidationIssue]:
                 ValidationIssue(
                     severity=Severity.WARNING,
                     category="STRATEGY_INCONSISTENT",
-                    attribute=attr.name,
+                    location=attr.name,
                     message="derived strategy has distribution (will be ignored)",
                 )
             )
@@ -788,7 +788,7 @@ def _check_strategy_consistency(attr: AttributeSpec) -> list[ValidationIssue]:
                 ValidationIssue(
                     severity=Severity.ERROR,
                     category="STRATEGY_INVALID",
-                    attribute=attr.name,
+                    location=attr.name,
                     message="derived strategy cannot have modifiers",
                 )
             )
@@ -799,7 +799,7 @@ def _check_strategy_consistency(attr: AttributeSpec) -> list[ValidationIssue]:
                 ValidationIssue(
                     severity=Severity.ERROR,
                     category="STRATEGY_INVALID",
-                    attribute=attr.name,
+                    location=attr.name,
                     message="conditional strategy requires distribution",
                 )
             )
@@ -808,7 +808,7 @@ def _check_strategy_consistency(attr: AttributeSpec) -> list[ValidationIssue]:
                 ValidationIssue(
                     severity=Severity.WARNING,
                     category="STRATEGY_INCONSISTENT",
-                    attribute=attr.name,
+                    location=attr.name,
                     message="conditional strategy has no depends_on (should be independent?)",
                 )
             )
@@ -817,7 +817,7 @@ def _check_strategy_consistency(attr: AttributeSpec) -> list[ValidationIssue]:
                 ValidationIssue(
                     severity=Severity.ERROR,
                     category="STRATEGY_INVALID",
-                    attribute=attr.name,
+                    location=attr.name,
                     message="conditional strategy cannot have formula",
                 )
             )

--- a/todos/issue1_validation_solution.md
+++ b/todos/issue1_validation_solution.md
@@ -1,0 +1,74 @@
+# Issue 1: Validation Consolidation
+
+## Problem
+
+Multiple validation pathways in `population/` each had their own validation patterns:
+
+1. **`validator/__init__.py`**: Used `@dataclass` for `Severity`, `ValidationIssue`, `ValidationResult`
+2. **`architect/quick_validate.py`**: Plain Python classes `ValidationError`, `QuickValidationResult`
+3. **`core/models/scenario.py`**: Pydantic models `ValidationError`, `ValidationWarning`, `ValidationResult`
+
+This inconsistency led to:
+- Code duplication
+- Type confusion when passing validation results between modules
+- Difficult maintenance
+
+## Solution
+
+Consolidated all validation types into a single unified module: `entropy/core/models/validation.py`
+
+### New Central Module: `core/models/validation.py`
+
+```python
+class Severity(str, Enum):
+    ERROR = "error"
+    WARNING = "warning"
+    INFO = "info"
+
+class ValidationIssue(BaseModel):
+    severity: Severity = Severity.ERROR
+    category: str
+    location: str
+    message: str
+    suggestion: str | None = None
+    modifier_index: int | None = None
+    value: str | None = None
+
+class ValidationResult(BaseModel):
+    issues: list[ValidationIssue] = []
+
+    @property
+    def valid(self) -> bool: ...
+    @property
+    def errors(self) -> list[ValidationIssue]: ...
+    @property
+    def warnings(self) -> list[ValidationIssue]: ...
+
+    def add_error(...): ...
+    def add_warning(...): ...
+    def format_for_retry(self) -> str: ...
+```
+
+### Files Modified
+
+1. **`core/models/validation.py`** - NEW: Unified Pydantic models
+2. **`core/models/__init__.py`** - Added validation imports
+3. **`core/models/scenario.py`** - Imports from validation.py (backwards compat)
+4. **`population/validator/__init__.py`** - Removed @dataclass, imports from core
+5. **`population/validator/syntactic.py`** - Uses core models, `location=` instead of `attribute=`
+6. **`population/validator/semantic.py`** - Uses core models, `location=` instead of `attribute=`
+7. **`population/architect/quick_validate.py`** - Uses core models with `_make_error()` helper
+
+### Backwards Compatibility
+
+Aliases maintained for existing code:
+- `ValidationError = ValidationIssue`
+- `ValidationWarning = ValidationIssue`
+- `QuickValidationResult = ValidationResult`
+
+### Key Changes
+
+1. **Field rename**: `attribute=` → `location=` (more generic, works for scenario validation too)
+2. **Single issues list**: `ValidationResult.issues` replaces separate `errors`, `warnings`, `info` lists
+3. **Computed properties**: `valid`, `errors`, `warnings` are now computed from `issues`
+4. **LLM retry support**: `format_for_retry()` and `for_llm_retry()` for fail-fast validation


### PR DESCRIPTION
This addresses Issue 1 from todos/phase1.md - Multiple Validation Pathways.

Changes:
- Create unified validation models in core/models/validation.py:
  - Severity enum (ERROR, WARNING, INFO)
  - ValidationIssue (Pydantic model with location, message, etc.)
  - ValidationResult (with add_error/warning/info, format_for_retry, etc.)

- Update core/models/__init__.py:
  - Export validation types from validation.py
  - Add backwards compat aliases (ValidationError, ValidationWarning)

- Update core/models/scenario.py:
  - Remove inline validation class definitions
  - Import from validation.py instead

- Update population/validator/:
  - Remove @dataclass definitions from __init__.py
  - Import Severity, ValidationIssue, ValidationResult from core
  - Update syntactic.py and semantic.py to use 'location=' instead of 'attribute='

- Update population/architect/quick_validate.py:
  - Replace custom classes with imports from core.models.validation
  - Add _make_error() helper for consistent error creation
  - Add backwards compat aliases

- Update population/architect/__init__.py:
  - Export validation types from core.models.validation
  - Add backwards compat aliases

Benefits:
- Single source of truth for validation types
- Pydantic everywhere (consistent with codebase)
- Composable results (result1 + result2)
- Unified format_for_retry() API