### PR TITLE
refactor: delete quick_validate.py and merge into validator/

### DIFF
--- a/entropy/population/architect/__init__.py
+++ b/entropy/population/architect/__init__.py
@@ -21,7 +21,7 @@ Pipeline (Overlay Mode):
 
 FAIL-FAST VALIDATION:
     Each hydration step validates LLM output immediately and retries with
-    error feedback if syntax errors are detected. See quick_validate.py.
+    error feedback if syntax errors are detected. See validator/llm_response.py.
 """
 
 from .sufficiency import check_sufficiency
@@ -34,7 +34,7 @@ from .hydrator import (
     hydrate_conditional_modifiers,
 )
 from .binder import bind_constraints, build_spec
-from .quick_validate import (
+from ..validator import (
     QuickValidationResult,
     ValidationError as QuickValidationError,
     validate_formula_syntax,

--- a/entropy/population/architect/hydrator.py
+++ b/entropy/population/architect/hydrator.py
@@ -43,7 +43,7 @@ from .hydrator_utils import (
     # Sanitization
     sanitize_formula,
 )
-from .quick_validate import (
+from ..validator import (
     validate_independent_response,
     validate_derived_response,
     validate_conditional_base_response,

--- a/entropy/population/validator/__init__.py
+++ b/entropy/population/validator/__init__.py
@@ -6,7 +6,8 @@ All checks are structural or mathematical - no sampling required.
 Module structure:
 - syntactic.py: Categories 1-9 (ERROR checks - blocks sampling)
 - semantic.py: Categories 10-12 (WARNING checks - sampling proceeds)
-- probabilistic.py: Stub for post-sample analysis (Phase 2)
+- llm_response.py: Fail-fast validation for LLM outputs
+- fixer.py: Auto-fix utilities
 """
 
 from ...core.models import PopulationSpec
@@ -17,6 +18,27 @@ from ...core.models.validation import (
 )
 
 from .fixer import fix_modifier_conditions, fix_spec_file, ConditionFix, FixResult
+
+# LLM response validation (moved from architect/quick_validate.py)
+from .llm_response import (
+    # Backwards compat aliases
+    ValidationError,
+    QuickValidationResult,
+    # Utility functions
+    is_spec_level_constraint,
+    extract_bound_from_constraint,
+    # Syntax validation
+    validate_formula_syntax,
+    validate_condition_syntax,
+    # Data validation
+    validate_distribution_data,
+    validate_modifier_data,
+    # Full response validation
+    validate_independent_response,
+    validate_derived_response,
+    validate_conditional_base_response,
+    validate_modifiers_response,
+)
 
 
 def validate_spec(spec: PopulationSpec) -> ValidationResult:
@@ -55,10 +77,28 @@ def validate_spec(spec: PopulationSpec) -> ValidationResult:
 
 
 __all__ = [
+    # Core validation types
     "Severity",
     "ValidationIssue",
     "ValidationResult",
+    # Backwards compat aliases
+    "ValidationError",
+    "QuickValidationResult",
+    # Spec validation
     "validate_spec",
+    # LLM response validation
+    "validate_formula_syntax",
+    "validate_condition_syntax",
+    "validate_distribution_data",
+    "validate_modifier_data",
+    "validate_independent_response",
+    "validate_derived_response",
+    "validate_conditional_base_response",
+    "validate_modifiers_response",
+    # Utility functions
+    "is_spec_level_constraint",
+    "extract_bound_from_constraint",
+    # Fixer
     "fix_modifier_conditions",
     "fix_spec_file",
     "ConditionFix",

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -1209,11 +1209,11 @@ class TestConstraintValidation:
 
 
 class TestQuickValidation:
-    """Tests for quick_validate.py validation functions."""
+    """Tests for LLM response validation functions (validator/llm_response.py)."""
 
     def test_quick_validate_catches_spec_level_constraint(self):
         """validate_independent_response should catch spec-level constraints with wrong type."""
-        from entropy.population.architect.quick_validate import (
+        from entropy.population.validator import (
             validate_independent_response,
         )
 
@@ -1243,7 +1243,7 @@ class TestQuickValidation:
 
     def test_quick_validate_conditional_catches_missing_max_formula(self):
         """validate_conditional_base_response should catch missing max_formula."""
-        from entropy.population.architect.quick_validate import (
+        from entropy.population.validator import (
             validate_conditional_base_response,
         )
 
@@ -1279,7 +1279,7 @@ class TestQuickValidation:
 
     def test_quick_validate_conditional_passes_with_max_formula(self):
         """validate_conditional_base_response should pass when max_formula is present."""
-        from entropy.population.architect.quick_validate import (
+        from entropy.population.validator import (
             validate_conditional_base_response,
         )
 
@@ -1314,7 +1314,7 @@ class TestQuickValidation:
 
     def test_quick_validate_error_message_is_prescriptive(self):
         """Error messages should tell LLM exactly what to fix."""
-        from entropy.population.architect.quick_validate import (
+        from entropy.population.validator import (
             validate_conditional_base_response,
         )
 
@@ -1352,7 +1352,7 @@ class TestQuickValidation:
 
     def test_quick_validate_accepts_static_max_for_constraint(self):
         """Static max should satisfy max bound requirement (not just max_formula)."""
-        from entropy.population.architect.quick_validate import (
+        from entropy.population.validator import (
             validate_conditional_base_response,
         )
 


### PR DESCRIPTION
- Create validator/llm_response.py with LLM response validation logic
- Delete architect/quick_validate.py (moved to validator/)
- Update validator/__init__.py to export LLM validation functions
- Update architect/__init__.py and hydrator.py imports
- Remove duplicated functions from hydrator_utils.py (is_spec_level_constraint, extract_bound_from_constraint)
- Update test imports in tests/test_sampler.py

This completes the validation consolidation by:
1. Keeping all validation types in core/models/validation.py
2. Keeping all validation logic in population/validator/
3. Removing code duplication