### PR TITLE
Add simulation validation unit tests

### DIFF
--- a/docs/impl-plan-simulation-tests.md
+++ b/docs/impl-plan-simulation-tests.md
@@ -1,0 +1,604 @@
+# Implementation Plan: Simulation Unit & Integration Tests (Parts 1-3)
+
+Branch: `validation/simulation-unit-tests`
+
+## Overview
+
+Three new test files, one extended conftest, zero LLM calls. Each section below is a test class with exact test methods, the function under test, and what's being asserted. Follows existing patterns: pytest classes, `_make_*` helpers, `tmp_path` for SQLite, fixtures from conftest.
+
+---
+
+## File 1: `tests/test_conviction.py`
+
+Tests the conviction system in isolation. Functions under test live in `entropy/core/models/simulation.py`.
+
+### Imports
+
+```python
+import pytest
+from entropy.core.models import (
+    ConvictionLevel,
+    CONVICTION_MAP,
+    CONVICTION_REVERSE_MAP,
+    conviction_to_float,
+    float_to_conviction,
+    score_to_conviction_float,
+)
+```
+
+### Class: `TestScoreToConvictionFloat`
+
+Tests `score_to_conviction_float()` — the 0-100 → float bucketing.
+
+| Test Method | Input | Expected Output | Notes |
+|---|---|---|---|
+| `test_very_uncertain_low_boundary` | `0` | `0.1` | Bottom of range |
+| `test_very_uncertain_high_boundary` | `15` | `0.1` | Top of very_uncertain bucket |
+| `test_leaning_low_boundary` | `16` | `0.3` | Transition point |
+| `test_leaning_high_boundary` | `35` | `0.3` | Top of leaning bucket |
+| `test_moderate_low_boundary` | `36` | `0.5` | |
+| `test_moderate_high_boundary` | `60` | `0.5` | |
+| `test_firm_low_boundary` | `61` | `0.7` | |
+| `test_firm_high_boundary` | `85` | `0.7` | |
+| `test_absolute_low_boundary` | `86` | `0.9` | |
+| `test_absolute_high_boundary` | `100` | `0.9` | |
+| `test_none_returns_none` | `None` | `None` | |
+| `test_float_input_accepted` | `50.0` | `0.5` | Score can be float |
+| `test_midpoint_values` | `25, 50, 75` | `0.3, 0.5, 0.7` | Typical values |
+
+Could also use `@pytest.mark.parametrize` for the boundary pairs to reduce boilerplate.
+
+### Class: `TestFloatToConviction`
+
+Tests `float_to_conviction()` — float → nearest level string.
+
+| Test Method | Input | Expected Output |
+|---|---|---|
+| `test_exact_values` | `0.1, 0.3, 0.5, 0.7, 0.9` | Each maps to its ConvictionLevel |
+| `test_nearest_rounding` | `0.2` | `"very_uncertain"` (closer to 0.1) or `"leaning"` (closer to 0.3) — verify actual behavior |
+| `test_none_returns_none` | `None` | `None` |
+| `test_zero` | `0.0` | `"very_uncertain"` (nearest to 0.1) |
+| `test_one` | `1.0` | `"absolute"` (nearest to 0.9) |
+
+### Class: `TestConvictionToFloat`
+
+Tests `conviction_to_float()` — level string → float.
+
+| Test Method | Input | Expected |
+|---|---|---|
+| `test_all_levels` | Each `ConvictionLevel` value | Matches `CONVICTION_MAP` |
+| `test_none_returns_none` | `None` | `None` |
+| `test_invalid_string` | `"invalid"` | `None` |
+
+### Class: `TestConvictionMaps`
+
+Tests `CONVICTION_MAP` and `CONVICTION_REVERSE_MAP` consistency.
+
+| Test Method | What |
+|---|---|
+| `test_map_has_five_levels` | `len(CONVICTION_MAP) == 5` |
+| `test_reverse_map_roundtrip` | Every value in CONVICTION_MAP is a key in CONVICTION_REVERSE_MAP and vice versa |
+| `test_values_are_ordered` | `very_uncertain < leaning < moderate < firm < absolute` |
+| `test_engine_constants_match` | Import engine's `_FIRM_CONVICTION`, `_MODERATE_CONVICTION`, `_SHARING_CONVICTION_THRESHOLD` and verify they match `CONVICTION_MAP` values |
+
+---
+
+## File 2: `tests/test_propagation.py`
+
+Tests exposure propagation and network spreading. Functions under test in `entropy/simulation/propagation.py`.
+
+### Imports
+
+```python
+import random
+from datetime import datetime
+
+import pytest
+
+from entropy.core.models import ExposureRecord, SimulationEventType
+from entropy.core.models.scenario import (
+    Event, EventType, ExposureChannel, ExposureRule,
+    InteractionConfig, InteractionType, OutcomeConfig,
+    ScenarioMeta, ScenarioSpec, SeedExposure, SimulationConfig,
+    SpreadConfig, TimestepUnit, ShareModifier,
+)
+from entropy.simulation.propagation import (
+    apply_seed_exposures,
+    calculate_share_probability,
+    evaluate_exposure_rule,
+    get_channel_credibility,
+    get_neighbors,
+    propagate_through_network,
+)
+from entropy.simulation.state import StateManager
+```
+
+### Fixtures (local to file)
+
+- `rng`: `random.Random(42)` — or reuse from conftest
+- `ten_agents`: 10 agents with `_id` "a0"-"a9" and attributes `age`, `role`
+- `linear_network`: Chain a0→a1→a2→...→a9 (9 edges)
+- `star_network`: Hub a0, spokes a1-a9 (9 edges)
+- `disconnected_network`: a0-a1 connected, a2-a9 isolated (1 edge)
+- `base_scenario`: Reuse `minimal_scenario` pattern from test_engine.py with configurable rules
+- `_make_scenario(**overrides)`: Helper to create scenario with custom seed_exposure rules, spread config
+
+### Class: `TestEvaluateExposureRule`
+
+Tests `evaluate_exposure_rule(rule, agent, timestep)`.
+
+| Test Method | Setup | Expected |
+|---|---|---|
+| `test_matching_timestep_and_condition` | rule timestep=0, when="true", agent any, timestep=0 | `True` |
+| `test_wrong_timestep` | rule timestep=0, timestep=1 | `False` |
+| `test_condition_filters_agent` | rule when="age > 40", agent age=30 | `False` |
+| `test_condition_matches_agent` | rule when="age > 40", agent age=50 | `True` |
+| `test_always_true_condition` | rule when="true" | `True` for any agent |
+
+### Class: `TestGetChannelCredibility`
+
+Tests `get_channel_credibility(scenario, channel_name)`.
+
+| Test Method | Setup | Expected |
+|---|---|---|
+| `test_existing_channel` | Channel "broadcast" with credibility_modifier=0.8 | `0.8` |
+| `test_missing_channel_returns_default` | Channel name not in scenario | `1.0` |
+
+### Class: `TestApplySeedExposures`
+
+Tests `apply_seed_exposures(timestep, scenario, agents, state_manager, rng)`.
+
+| Test Method | Setup | Expected |
+|---|---|---|
+| `test_all_agents_exposed_broadcast` | prob=1.0, when="true", 10 agents | Returns 10, all agents aware |
+| `test_no_exposure_wrong_timestep` | Rule for timestep=5, called at timestep=0 | Returns 0 |
+| `test_conditional_exposure` | when="role == 'senior'", 3 seniors out of 10 | Returns 3, only seniors aware |
+| `test_probabilistic_exposure` | prob=0.5, seeded rng | Returns between 0 and 10, deterministic with seed |
+| `test_credibility_calculation` | event.credibility=0.9, channel.credibility_modifier=0.8 | Exposure records have credibility=0.72 |
+| `test_multiple_rules_same_timestep` | Two rules at timestep=0, different conditions | Both applied, agents can get multiple exposures |
+| `test_already_aware_agent_gets_new_exposure` | Expose agent twice | exposure_count=2, still one aware agent |
+
+### Class: `TestGetNeighbors`
+
+Tests `get_neighbors(network, agent_id)`.
+
+| Test Method | Setup | Expected |
+|---|---|---|
+| `test_hub_of_star` | Star network, agent "a0" | 9 neighbors |
+| `test_spoke_of_star` | Star network, agent "a1" | 1 neighbor (a0) |
+| `test_isolated_agent` | Disconnected network, agent "a5" | 0 neighbors |
+| `test_bidirectional` | Edge source=a0, target=a1 | a0 sees a1, a1 sees a0 |
+
+### Class: `TestCalculateShareProbability`
+
+Tests `calculate_share_probability(agent, edge_data, spread_config, rng)`.
+
+| Test Method | Setup | Expected |
+|---|---|---|
+| `test_base_probability` | No modifiers, base=0.3 | Returns 0.3 |
+| `test_modifier_multiply` | Modifier when="true", multiply=2.0, add=0 | Returns 0.6 |
+| `test_modifier_add` | Modifier when="true", multiply=1.0, add=0.1 | Returns 0.4 |
+| `test_modifier_clamp_upper` | Modifier pushes prob to 1.5 | Returns 1.0 |
+| `test_modifier_clamp_lower` | Modifier pushes prob negative | Returns 0.0 |
+| `test_condition_not_met` | Modifier when="age > 100", agent age=30 | Returns base (0.3) |
+| `test_edge_type_in_context` | Modifier when="edge_type == 'mentor'", edge type="mentor" | Modifier applied |
+
+### Class: `TestPropagateThrough Network`
+
+Tests `propagate_through_network(...)`.
+
+| Test Method | Setup | Expected |
+|---|---|---|
+| `test_single_sharer_linear_chain` | a0 shares, linear chain, prob=1.0 | a1 exposed (one hop only, a2 not exposed this timestep) |
+| `test_hub_sharer_star_network` | a0 shares, star network, prob=1.0 | All 9 spokes exposed |
+| `test_no_sharers_no_propagation` | No agents have will_share=True | Returns 0 |
+| `test_conviction_gated_sharing` | This is tested at engine level — here just test that `get_sharers()` returns empty when no sharers in DB |
+| `test_peer_credibility_is_085` | a0 shares to a1 | Exposure record has credibility=0.85 |
+| `test_already_aware_still_gets_exposure` | a1 already aware, a0 shares | a1 gets new exposure (exposure_count increments), for multi-touch |
+| `test_adjacency_list_used` | Pass adjacency dict, verify no `get_neighbors()` fallback (check exposures match adjacency structure) |
+| `test_probabilistic_sharing` | share_prob=0.5, seeded rng, many edges | Deterministic subset exposed |
+
+**Important setup detail:** For propagation tests, agents need to already be in the `will_share=True` state in the StateManager before calling `propagate_through_network()`. This means:
+1. Create StateManager with agents
+2. Record an exposure for the sharer agent
+3. Update the sharer's state to `will_share=True`
+4. Then call `propagate_through_network()`
+
+---
+
+## File 3: `tests/test_stopping.py`
+
+Tests stopping condition evaluation. Functions under test in `entropy/simulation/stopping.py`.
+
+### Imports
+
+```python
+import pytest
+
+from entropy.core.models import TimestepSummary
+from entropy.core.models.scenario import SimulationConfig, TimestepUnit
+from entropy.simulation.stopping import (
+    evaluate_comparison,
+    evaluate_condition,
+    evaluate_convergence,
+    evaluate_no_state_changes,
+    evaluate_stopping_conditions,
+    parse_comparison,
+)
+from entropy.simulation.state import StateManager
+```
+
+### Fixtures
+
+- `_make_summary(**overrides)`: Factory for `TimestepSummary` with sensible defaults
+- `_make_summaries(n, **shared_overrides)`: Creates a list of n summaries for sliding window tests
+- `_make_config(**overrides)`: Factory for `SimulationConfig` with defaults
+
+### Class: `TestParseComparison`
+
+Tests `parse_comparison(condition)`.
+
+| Test Method | Input | Expected |
+|---|---|---|
+| `test_greater_than` | `"exposure_rate > 0.95"` | `("exposure_rate", ">", 0.95)` |
+| `test_less_than` | `"average_sentiment < 0.0"` | `("average_sentiment", "<", 0.0)` |
+| `test_greater_equal` | `"exposure_rate >= 1.0"` | `("exposure_rate", ">=", 1.0)` |
+| `test_equal` | `"state_changes == 0"` | `("state_changes", "==", 0.0)` |
+| `test_not_equal` | `"exposure_rate != 0.0"` | `("exposure_rate", "!=", 0.0)` |
+| `test_invalid_format` | `"not a condition"` | `None` |
+| `test_whitespace_handling` | `"  exposure_rate  >  0.95  "` | `("exposure_rate", ">", 0.95)` |
+
+### Class: `TestEvaluateNoStateChanges`
+
+Tests `evaluate_no_state_changes(condition, recent_summaries)`.
+
+| Test Method | Setup | Expected |
+|---|---|---|
+| `test_stable_for_threshold` | `"no_state_changes_for > 10"`, 11 summaries with state_changes=0 | `True` |
+| `test_not_stable_enough` | `"no_state_changes_for > 10"`, 10 summaries with state_changes=0 | `False` (need >10, not ==10) |
+| `test_recent_change_breaks_stability` | 15 summaries, last one has state_changes=1 | `False` |
+| `test_empty_summaries` | No summaries | `False` |
+
+### Class: `TestEvaluateConvergence`
+
+Tests `evaluate_convergence(recent_summaries, window, tolerance)`.
+
+| Test Method | Setup | Expected |
+|---|---|---|
+| `test_stable_distribution` | 5 summaries, identical position_distribution `{"adopt": 70, "reject": 30}` | `True` |
+| `test_shifting_distribution` | 5 summaries with varying distributions | `False` |
+| `test_insufficient_window` | 3 summaries, window=5 | `False` (not enough data) |
+| `test_custom_tolerance` | 5 summaries with small drift, tolerance=0.1 | `True` (within tolerance) |
+| `test_empty_position_distribution` | Summaries with empty dicts | Handle gracefully (False or True — verify actual behavior) |
+
+### Class: `TestEvaluateStoppingConditions`
+
+Tests the top-level `evaluate_stopping_conditions(timestep, config, state_manager, recent_summaries)`.
+
+| Test Method | Setup | Expected |
+|---|---|---|
+| `test_max_timesteps_reached` | timestep=99, max_timesteps=100 | `(True, "max_timesteps")` or similar reason string |
+| `test_before_max_timesteps` | timestep=50, max_timesteps=100, no conditions | `(False, None)` |
+| `test_exposure_rate_condition_met` | Condition `"exposure_rate > 0.95"`, state_manager with 96% aware | `(True, ...)` |
+| `test_exposure_rate_condition_not_met` | Condition `"exposure_rate > 0.95"`, state_manager with 50% aware | `(False, None)` |
+| `test_compound_condition_both_met` | (depends on whether compound `and` is supported at the `evaluate_condition` level — read the code to confirm) |
+| `test_no_stop_conditions` | Config with empty `stop_conditions` list, timestep < max | `(False, None)` |
+
+**Note:** These tests require a StateManager with agents initialized and some in aware state. Use `tmp_path` for SQLite DB, initialize agents, record exposures to set up desired exposure_rate.
+
+---
+
+## File 4: `tests/test_memory_traces.py`
+
+Tests memory trace storage and retrieval, plus the `get_agents_to_reason()` multi-touch logic. Functions under test in `entropy/simulation/state.py`.
+
+### Fixtures
+
+- `state_mgr(tmp_path)`: Creates StateManager with 5 agents, returns it
+- `_make_memory_entry(**overrides)`: Factory for `MemoryEntry`
+
+### Class: `TestMemoryTraceSliding Window`
+
+Tests `save_memory_entry()` and `get_memory_traces()`.
+
+| Test Method | Setup | Expected |
+|---|---|---|
+| `test_single_entry` | Save 1 memory entry for agent | `get_memory_traces()` returns 1 entry |
+| `test_three_entries_retained` | Save 3 entries | All 3 returned, ordered oldest→newest |
+| `test_fourth_entry_evicts_oldest` | Save 4 entries | Only latest 3 returned |
+| `test_fifth_entry_still_three` | Save 5 entries | Still 3, earliest 2 evicted |
+| `test_entries_ordered_by_timestep` | Save entries at timesteps 3, 1, 2 | Returned in order 1, 2, 3 |
+| `test_separate_agents` | Save entries for agent_a and agent_b | Each agent has independent trace |
+
+### Class: `TestGetAgentsToReason`
+
+Tests `get_agents_to_reason(timestep, threshold)`.
+
+| Test Method | Setup | Expected |
+|---|---|---|
+| `test_never_reasoned_aware_agent` | Agent aware (has exposure), never reasoned (last_reasoning_timestep=-1) | Agent in result list |
+| `test_unaware_agent_excluded` | Agent not exposed | Not in result list |
+| `test_multi_touch_below_threshold` | Agent reasoned at t=0, got 2 new exposures (threshold=3) | Not in result list |
+| `test_multi_touch_at_threshold` | Agent reasoned at t=0, got 3 new exposures (threshold=3) | In result list |
+| `test_multi_touch_above_threshold` | Agent reasoned at t=0, got 5 new exposures (threshold=3) | In result list |
+| `test_recently_reasoned_no_new_exposures` | Agent reasoned at t=5, no new exposures since | Not in result list |
+
+**Setup notes:** Multi-touch tests require:
+1. Initialize agents
+2. Record initial exposure (makes agent aware)
+3. Update agent state with `last_reasoning_timestep` set
+4. Record additional exposures after that timestep
+5. Call `get_agents_to_reason(current_timestep, threshold)`
+
+### Class: `TestStateManagerAggregations`
+
+Tests analytics queries that aren't covered in existing `test_simulation.py`.
+
+| Test Method | Setup | Expected |
+|---|---|---|
+| `test_get_sentiment_variance` | 5 agents with sentiments [0.1, 0.3, 0.5, 0.7, 0.9] | Returns correct variance |
+| `test_get_sentiment_variance_none_when_no_data` | No agents with sentiment | Returns `None` |
+| `test_get_average_conviction` | 5 agents with varied convictions | Returns correct mean |
+| `test_get_population_count` | 10 agents initialized | Returns 10 |
+
+---
+
+## File 5: `tests/test_reasoning_prompts.py`
+
+Tests prompt construction and schema generation. Functions under test in `entropy/simulation/reasoning.py`. No LLM calls — just string/dict construction.
+
+### Imports
+
+```python
+import pytest
+
+from entropy.core.models import (
+    ExposureRecord, MemoryEntry, PeerOpinion,
+    ReasoningContext, AgentState,
+    float_to_conviction,
+)
+from entropy.core.models.scenario import (
+    OutcomeConfig, OutcomeDefinition, OutcomeType,
+    # ... scenario models for build_pass2_schema
+)
+from entropy.simulation.reasoning import (
+    build_pass1_prompt,
+    build_pass1_schema,
+    build_pass2_prompt,
+    build_pass2_schema,
+    _get_primary_position_outcome,
+    _sentiment_to_tone,
+)
+```
+
+### Fixtures
+
+- `_make_context(**overrides)`: Factory for `ReasoningContext` with default persona, event, exposure
+- `_make_scenario(**overrides)`: Factory reusing pattern from test_engine.py
+
+### Class: `TestBuildPass1Prompt`
+
+Tests `build_pass1_prompt(context, scenario)`.
+
+| Test Method | What's Asserted |
+|---|---|
+| `test_persona_included` | Context persona string appears in output |
+| `test_event_content_included` | `scenario.event.content` appears in output |
+| `test_event_source_included` | `scenario.event.source` appears in output |
+| `test_seed_exposure_shows_channel` | Exposure with no `source_agent_id` → "You heard about this via {channel}" |
+| `test_network_exposure_shows_peer` | Exposure with `source_agent_id` set → "Someone in your network told you" |
+| `test_no_memory_section_on_first_reasoning` | Empty `memory_trace` → no "Your Previous Thinking" section |
+| `test_memory_trace_included` | 2 memory entries → "Your Previous Thinking" section with conviction labels via `float_to_conviction()` |
+| `test_peer_opinions_included` | 2 `PeerOpinion` entries → "What People Around You Are Saying" section with `public_statement` |
+| `test_peer_opinions_use_sentiment_tone_not_position` | Peer with position="reject" → position does NOT appear in prompt; sentiment tone does |
+| `test_anti_hedging_instructions` | Prompt contains "Do NOT hedge" or similar anti-central-tendency language |
+
+### Class: `TestBuildPass1Schema`
+
+Tests `build_pass1_schema()`.
+
+| Test Method | What's Asserted |
+|---|---|
+| `test_has_required_fields` | Schema has: reasoning, public_statement, reasoning_summary, sentiment, conviction, will_share |
+| `test_sentiment_range` | Sentiment field has minimum=-1, maximum=1 |
+| `test_conviction_range` | Conviction field has minimum=0, maximum=100, type=integer |
+| `test_will_share_is_boolean` | will_share has type=boolean |
+
+### Class: `TestBuildPass2Prompt`
+
+Tests `build_pass2_prompt(reasoning_text, scenario)`.
+
+| Test Method | What's Asserted |
+|---|---|
+| `test_reasoning_text_included` | Input reasoning text appears in output |
+| `test_classification_instruction` | Contains "classify" or similar |
+| `test_outcomes_described` | Outcome descriptions from scenario appear |
+
+### Class: `TestBuildPass2Schema`
+
+Tests `build_pass2_schema(outcomes)`.
+
+| Test Method | Setup | What's Asserted |
+|---|---|---|
+| `test_categorical_outcome` | OutcomeDefinition type=CATEGORICAL, options=["a","b","c"] | Schema has enum field |
+| `test_boolean_outcome` | OutcomeDefinition type=BOOLEAN | Schema has boolean field |
+| `test_float_outcome` | OutcomeDefinition type=FLOAT, range=[0,10] | Schema has number field with min/max |
+| `test_open_ended_outcome` | OutcomeDefinition type=OPEN_ENDED | Schema has string field |
+| `test_multiple_outcomes` | 3 different outcomes | All appear in schema |
+| `test_no_outcomes_returns_none` | Empty OutcomeConfig | Returns `None` |
+
+### Class: `TestHelpers`
+
+| Test Method | Function | Input | Expected |
+|---|---|---|---|
+| `test_sentiment_very_negative` | `_sentiment_to_tone` | `-0.9` | `"strongly opposed"` or similar |
+| `test_sentiment_negative` | `_sentiment_to_tone` | `-0.3` | `"skeptical"` or similar |
+| `test_sentiment_neutral` | `_sentiment_to_tone` | `0.0` | `"neutral"` |
+| `test_sentiment_positive` | `_sentiment_to_tone` | `0.5` | `"positive"` |
+| `test_sentiment_very_positive` | `_sentiment_to_tone` | `0.9` | `"enthusiastic"` |
+| `test_primary_position_outcome` | `_get_primary_position_outcome` | Scenario with required categorical | Returns outcome name |
+| `test_primary_position_no_categorical` | `_get_primary_position_outcome` | Scenario with only boolean outcomes | Returns `None` |
+
+---
+
+## File 6: `tests/test_integration_timestep.py`
+
+Integration tests for the full timestep loop with mocked LLM calls. Tests the engine's `_execute_timestep()` and `run()` methods.
+
+### Imports
+
+```python
+import random
+from datetime import datetime
+from unittest.mock import AsyncMock, patch, MagicMock
+
+import pytest
+
+from entropy.core.models import (
+    AgentState, ConvictionLevel, CONVICTION_MAP,
+    ExposureRecord, ReasoningResponse, SimulationRunConfig,
+    TimestepSummary,
+)
+from entropy.core.models.scenario import (
+    # ... all scenario model imports from test_engine.py
+)
+from entropy.simulation.engine import SimulationEngine
+```
+
+### Fixtures
+
+- `ten_agents`: 10 agents with _id "a0"-"a9", varied attributes
+- `chain_network`: a0→a1→a2→...→a9
+- `scenario_with_targeted_seed`: Seed rule exposes only a0 at timestep 0 (when=`"_id == 'a0'"` or similar condition that matches only one agent)
+- `engine_factory(scenario, agents, network, tmp_path)`: Helper that creates a `SimulationEngine` with given params, returns engine
+
+### Class: `TestSingleTimestepE2E`
+
+Tests `_execute_timestep()` with mocked `batch_reason_agents`.
+
+| Test Method | Setup | What's Asserted |
+|---|---|---|
+| `test_seed_then_reason_then_update` | Scenario seeds a0 at t=0. Mock `batch_reason_agents` returns canned response for a0. | After timestep 0: a0 is aware, has position, has memory entry. a1 not yet aware. |
+| `test_propagation_after_reasoning` | After t=0 (a0 reasoned, will_share=True), run t=1. | a1 gets network exposure from a0 (one hop in chain). a2 still unaware. |
+| `test_timeline_events_logged` | Run t=0. | Timeline has SEED_EXPOSURE event for a0, AGENT_REASONED event for a0. |
+| `test_timestep_summary_computed` | Run t=0 with 1 seed exposure. | Summary has new_exposures=1, agents_reasoned=1, exposure_rate=0.1 (1/10). |
+| `test_transaction_wraps_timestep` | Mock an exception in reasoning. | State is rolled back — no partial updates visible. |
+
+**Mocking strategy:** Patch `entropy.simulation.engine.batch_reason_agents` (the import in engine.py). The mock returns a list of `(agent_id, ReasoningResponse)` tuples. Use `_make_reasoning_response()` helper.
+
+### Class: `TestMultiTimestepDynamics`
+
+Tests `engine.run()` over multiple timesteps with mocked LLM.
+
+| Test Method | Setup | What's Asserted |
+|---|---|---|
+| `test_information_cascade_through_chain` | Chain network, seed a0 at t=0, share_prob=1.0. Mock returns will_share=True, moderate conviction. | Over timesteps, exposure propagates a0→a1→a2→...→a9. After 10 timesteps, all agents aware. |
+| `test_exposure_rate_monotonically_increases` | Same as above. | Each timestep summary has exposure_rate >= previous. |
+| `test_re_reasoning_with_memory` | a0 reasoned at t=0, gets 3 new network exposures by t=3. Mock returns different sentiment on re-reason. | a0 re-reasons at t=3 (multi-touch threshold=3). Memory trace fed back. New state differs from t=0 state. |
+| `test_stopping_condition_triggers` | Config with stop_condition `"exposure_rate > 0.5"`. | Simulation stops before max_timesteps. `SimulationSummary.stopped_reason` is set. |
+| `test_isolated_agent_never_exposed` | Chain a0-a8, a9 isolated (no edges). Seed only a0. | After all timesteps, a9 still unaware. |
+
+**Mocking detail for cascade test:** The mock for `batch_reason_agents` needs to be dynamic — it receives a list of contexts and must return a response for each. Use `side_effect` that inspects the input contexts and returns appropriate `_make_reasoning_response()` for each agent:
+
+```python
+def mock_batch_reason(contexts, scenario, config, max_concurrency=50, rate_limiter=None):
+    return [
+        (ctx.agent_id, _make_reasoning_response(will_share=True))
+        for ctx in contexts
+    ]
+```
+
+### Class: `TestIsolatedAgent`
+
+Tests single-agent behavior with no network effects.
+
+| Test Method | Setup | What's Asserted |
+|---|---|---|
+| `test_single_agent_reasons_once` | 1 agent, empty network, seed at t=0. | Agent reasons exactly once (mock called once). No propagation. |
+| `test_no_peer_opinions_in_context` | 1 agent, no neighbors. | `ReasoningContext.peer_opinions` is empty list. |
+
+---
+
+## Additions to `tests/conftest.py`
+
+New shared fixtures needed across multiple new test files:
+
+```python
+@pytest.fixture
+def ten_agents():
+    """Ten agents with varied attributes for propagation/integration tests."""
+    agents = []
+    roles = ["junior", "mid", "senior"]
+    for i in range(10):
+        agents.append({
+            "_id": f"a{i}",
+            "age": 25 + i * 5,
+            "role": roles[i % 3],
+        })
+    return agents
+
+
+@pytest.fixture
+def linear_network(ten_agents):
+    """Chain network: a0-a1-a2-...-a9."""
+    edges = [
+        {"source": f"a{i}", "target": f"a{i+1}", "type": "colleague"}
+        for i in range(9)
+    ]
+    return {
+        "meta": {"node_count": 10},
+        "nodes": [{"id": f"a{i}"} for i in range(10)],
+        "edges": edges,
+    }
+
+
+@pytest.fixture
+def star_network(ten_agents):
+    """Star network: a0 is hub, a1-a9 are spokes."""
+    edges = [
+        {"source": "a0", "target": f"a{i}", "type": "colleague"}
+        for i in range(1, 10)
+    ]
+    return {
+        "meta": {"node_count": 10},
+        "nodes": [{"id": f"a{i}"} for i in range(10)],
+        "edges": edges,
+    }
+```
+
+---
+
+## Execution Order
+
+Implement in this order due to dependency:
+
+1. **`conftest.py` additions** — shared fixtures needed by everything else
+2. **`test_conviction.py`** — standalone, no dependencies on other new code
+3. **`test_stopping.py`** — standalone, tests pure functions with simple inputs
+4. **`test_propagation.py`** — depends on conftest network fixtures
+5. **`test_memory_traces.py`** — depends on conftest agent fixtures
+6. **`test_reasoning_prompts.py`** — depends on conftest fixtures, tests string output
+7. **`test_integration_timestep.py`** — depends on all of the above being green, uses mocked LLM
+
+---
+
+## What's NOT in scope
+
+- No live LLM calls (that's Part 4+)
+- No changes to production code (unless a test reveals a bug, which should be noted but not fixed in this PR)
+- No new production modules (metrics.py, scenario library — that's Part 7 infrastructure)
+- No async tests for `_reason_agent_two_pass_async` — the async mock setup is complex and the sync `reason_agent()` path covers the same logic; async can be added later
+- No performance/scale tests (100+ agents) — keep tests fast for CI
+
+## Test Count Summary
+
+| File | Classes | Tests | Lines (est.) |
+|---|---|---|---|
+| `test_conviction.py` | 4 | ~18 | ~150 |
+| `test_propagation.py` | 5 | ~22 | ~400 |
+| `test_stopping.py` | 4 | ~16 | ~250 |
+| `test_memory_traces.py` | 3 | ~16 | ~250 |
+| `test_reasoning_prompts.py` | 5 | ~22 | ~350 |
+| `test_integration_timestep.py` | 3 | ~12 | ~350 |
+| conftest additions | — | — | ~30 |
+| **Total** | **24** | **~106** | **~1780** |

--- a/docs/validation-plan.md
+++ b/docs/validation-plan.md
@@ -1,0 +1,387 @@
+# Simulation Phase Validation Plan
+
+Proving that entropy's simulation produces reliable, valid, and differentiated results.
+
+This plan draws on:
+- Roadmap items 4.1-4.4 (backtesting, central tendency, cost calibration, experiments)
+- Arxiv papers: opinion consensus in LLM networks, social digital twins, GTA, Sentipolis, AMBER
+- Competitor validation benchmarks: Aaru's EY replication (0.90 Spearman), Societies.io's LinkedIn R²=0.78
+- Current test coverage gaps identified in the codebase
+
+---
+
+## Part 1: Deterministic Unit-Level Validation
+
+Goal: prove each simulation sub-system works correctly in isolation, with zero LLM calls.
+
+### 1.1 Conviction Bucketing
+
+Test `score_to_conviction_float()` and `float_to_conviction()` roundtrips across all bucket boundaries.
+
+- [ ] Boundary values: 0, 15, 16, 35, 36, 60, 61, 85, 86, 100
+- [ ] Out-of-range inputs: -1, 101, 0.5
+- [ ] Verify `CONVICTION_MAP[ConvictionLevel.*]` matches the bucketing logic
+
+**Why first:** flip resistance and sharing gating both depend on correct bucketing. If this is wrong, everything downstream is wrong.
+
+### 1.2 Network Propagation
+
+Test `propagate_through_network()` with controlled adjacency lists and deterministic RNG.
+
+- [ ] Linear chain (A→B→C): verify single-hop propagation per timestep
+- [ ] Star graph (hub + spokes): verify hub exposure reaches all neighbors
+- [ ] Conviction-gated sharing: agent with conviction ≤ 0.1 (very_uncertain) should never propagate
+- [ ] Share probability modifiers: verify `calculate_share_probability()` applies multiply/add correctly
+- [ ] Credibility assignment: verify peer credibility = 0.85
+- [ ] Already-aware agents don't get re-exposed through same channel
+
+### 1.3 Stopping Conditions
+
+Test `evaluate_stopping_conditions()` with synthetic `TimestepSummary` sequences.
+
+- [ ] Max timesteps: stops at boundary
+- [ ] Exposure rate threshold: `"exposure_rate > 0.95"` triggers correctly
+- [ ] No-state-changes: `"no_state_changes_for > 10"` with exactly 10 vs 11 stable timesteps
+- [ ] Convergence detection: stable position distribution (< 5% variance over 5 timesteps)
+- [ ] Compound conditions with `and`
+- [ ] Sentiment variance stopping
+
+### 1.4 State Manager Integrity
+
+Test `StateManager` under adversarial conditions.
+
+- [ ] Memory trace sliding window: insert 5 entries, verify only latest 3 retained
+- [ ] `get_agents_to_reason()` multi-touch threshold: agent with 2 new exposures (threshold=3) should NOT reason; agent with 3 should
+- [ ] Batch update atomicity: partial failure in `batch_update_states()` rolls back entirely
+- [ ] Concurrent read/write safety under asyncio
+
+### 1.5 Flip Resistance Logic
+
+Test `_apply_state_updates()` flip resistance matrix exhaustively.
+
+- [ ] Firm agent (0.7) + weak new conviction (0.3) + position change → REJECT flip
+- [ ] Firm agent (0.7) + moderate new conviction (0.5) + position change → ACCEPT flip
+- [ ] Absolute agent (0.9) + moderate new conviction (0.5) + position change → ACCEPT flip
+- [ ] Leaning agent (0.3) + any new conviction + position change → ACCEPT flip (no resistance)
+- [ ] Same position, different conviction → no flip resistance check needed
+
+---
+
+## Part 2: Reasoning Pipeline Validation
+
+Goal: verify the two-pass architecture produces correct outputs, isolated from LLM behavior.
+
+### 2.1 Prompt Construction
+
+Test `build_pass1_prompt()` and `build_pass2_prompt()` produce well-formed prompts.
+
+- [ ] First-time reasoning: no memory trace section, no peer opinions section
+- [ ] Re-reasoning with memory: memory trace includes conviction label ("you felt *moderate* about this")
+- [ ] Peer influence formatting: public_statement + sentiment tone, NOT position label
+- [ ] Exposure history: correctly distinguishes network ("someone in your network") vs seed channel
+- [ ] Persona inclusion: full persona text appears in prompt
+
+### 2.2 Schema Construction
+
+Test `build_pass1_schema()` and `build_pass2_schema()`.
+
+- [ ] Pass 1 schema has: reasoning, public_statement, reasoning_summary, sentiment [-1,1], conviction [0,100], will_share
+- [ ] Pass 2 schema correctly maps categorical outcomes to enums
+- [ ] Pass 2 schema correctly maps boolean, float, open_ended outcomes
+- [ ] Pass 2 with no outcomes → empty schema → no Pass 2 call
+
+### 2.3 Two-Pass Integration (Mocked LLM)
+
+Test `_reason_agent_two_pass_async()` with mocked `simple_call_async()`.
+
+- [ ] Pass 1 produces ReasoningResponse with correct conviction bucketing
+- [ ] Pass 2 classifies into categorical outcomes correctly
+- [ ] Pass 2 failure is non-fatal (returns Pass 1 data with no outcomes)
+- [ ] Rate limiter acquisition: pivotal bucket for Pass 1, routine bucket for Pass 2
+- [ ] Retry logic: transient failure on attempt 1, success on attempt 2
+
+### 2.4 Batch Reasoning
+
+Test `batch_reason_agents()` concurrency behavior.
+
+- [ ] Stagger interval calculation: 500 RPM → 120ms between launches
+- [ ] Semaphore limiting: max_safe_concurrent respected
+- [ ] All agents get results (no dropped tasks)
+- [ ] Rate limiter stats populated after batch
+
+---
+
+## Part 3: Integration Tests (Full Timestep Loop)
+
+Goal: verify the three-phase timestep loop works end-to-end with mocked LLM.
+
+### 3.1 Single Timestep E2E
+
+Run `_execute_timestep()` with a 10-agent population, simple network, and mocked LLM.
+
+- [ ] Phase 1: seed exposure creates awareness for targeted agents
+- [ ] Phase 2: newly aware agents get reasoned (mocked two-pass)
+- [ ] Phase 3: state updates applied, memory entries saved, timeline events logged
+- [ ] Transaction commits on success; all state visible after timestep
+
+### 3.2 Multi-Timestep Dynamics
+
+Run full `engine.run()` for 5-10 timesteps with mocked LLM returning deterministic responses.
+
+- [ ] Information cascade: exposure spreads from seed agents through network over timesteps
+- [ ] Re-reasoning: agents exposed to 3+ new peers re-reason with memory trace
+- [ ] Stopping condition: simulation stops when configured condition is met (not just max timesteps)
+- [ ] Aggregation: `TimestepSummary` values are monotonically reasonable (exposure_rate never decreases)
+
+### 3.3 Isolated Agent Test
+
+Single agent, no network, single seed exposure.
+
+- [ ] Agent reasons exactly once
+- [ ] No propagation occurs (no neighbors)
+- [ ] Final state reflects single reasoning output
+- [ ] Useful as baseline for understanding LLM contribution vs. network contribution
+
+---
+
+## Part 4: LLM Behavior Validation (Live Calls, Small Scale)
+
+Goal: test whether the LLM reasoning layer produces meaningful, non-degenerate outputs. This is where the arxiv papers are most relevant.
+
+### 4.1 Anti-Central-Tendency Check
+
+**From roadmap 4.2.** Run a polarizing scenario with ~50 agents, real LLM calls.
+
+Validation criteria (from the central tendency fix):
+- [ ] Most popular position < 60% (no single option dominates)
+- [ ] Least popular position > 0% (all options represented)
+- [ ] Conviction std > 20 (across raw 0-100 scores)
+- [ ] "cautious" appears in < 40% of reasoning text
+- [ ] Sentiment std > 0.35
+
+**Scenarios to use:**
+1. **Obvious acceptance:** "Free premium upgrade for loyal customers" → expect near-universal positive response
+2. **Polarizing:** "Mandatory return-to-office policy for remote workers" → expect genuine split
+3. **Niche impact:** "Hospital switching to new surgical robot system" (German surgeon population) → expect domain-specific reasoning
+
+### 4.2 LLM Prior Dominance Test
+
+**Inspired by [Kayaalp et al., 2026](https://arxiv.org/abs/2601.21540).** Their finding: LLM agents converge to topic-biased attractors regardless of network structure. Entropy needs to verify its agents are actually influenced by persona + network, not just LLM priors.
+
+Test protocol:
+- [ ] **Same scenario, different populations**: Run identical event with (a) young tech workers and (b) retired traditionalists. Outcome distributions should differ significantly. If they don't, LLM priors are dominating persona context.
+- [ ] **Same population, different networks**: Run identical population+scenario with (a) dense network (avg_degree=10) and (b) sparse network (avg_degree=2). If results are identical, network structure isn't contributing.
+- [ ] **Peer influence ablation**: Run with peers' public_statements included vs. excluded from reasoning prompts. Measure delta in outcome distributions.
+
+Metric: Jensen-Shannon divergence between outcome distributions across conditions. JSD > 0.05 indicates meaningful differentiation.
+
+### 4.3 Persona Sensitivity Test
+
+**Inspired by [GTA, CHI 2026](https://arxiv.org/abs/2401.xxx) finding that demographic grounding reproduces socioeconomic patterns.**
+
+- [ ] Generate 100 agents, render personas, compare reasoning outputs by demographic segment
+- [ ] Verify: high-income agents respond differently to pricing changes than low-income agents
+- [ ] Verify: personality traits (Big Five) produce observable reasoning differences
+- [ ] Metric: segment-level outcome distributions should have statistically significant differences (chi-squared, p < 0.05)
+
+### 4.4 Temporal Dynamics Validation
+
+**Entropy's key differentiator vs. competitors.** Neither Aaru nor Societies.io does multi-timestep belief evolution.
+
+- [ ] Run 50-timestep simulation, plot conviction trajectory per agent
+- [ ] Verify: agents don't all converge to same conviction at same rate (which would indicate cargo-culting)
+- [ ] Verify: network-exposed agents shift earlier than broadcast-only agents (information flow matters)
+- [ ] Verify: re-reasoning agents show conviction drift (not just repeating first opinion)
+- [ ] Metric: Granger causality test between exposure events and conviction shifts
+
+---
+
+## Part 5: Calibration & Ground Truth (The Hard Part)
+
+Goal: compare simulation outputs to real-world outcomes. This is what makes or breaks entropy's credibility.
+
+### 5.1 Toy Scenarios with Known Answers
+
+**From roadmap 4.1.** Design scenarios where the expected outcome is obvious, then verify entropy agrees.
+
+| Scenario | Expected Result | Pass Criteria |
+|----------|----------------|---------------|
+| Free upgrade for loyal customers | >80% acceptance | Top position = accept, >80% |
+| 50% price increase, no new features | >60% negative | Sentiment mean < -0.2 |
+| Mandatory unpaid overtime | >70% opposition | Opposition > 70%, sentiment < -0.3 |
+| Paid sabbatical program announced | >70% positive | Sentiment mean > 0.3 |
+
+These aren't rigorous backtests — they're sanity checks. If entropy can't get directional calls right on obvious scenarios, nothing else matters.
+
+### 5.2 Historical Scenario Replication
+
+**From roadmap 4.1.** Pick 2-3 past events with known quantitative outcomes.
+
+Candidates:
+1. **COVID-19 mask mandate compliance** (well-studied, [Koaik et al.](https://arxiv.org/abs/2601.06111) used this domain) — simulate US population response to mask mandates, compare to actual compliance survey data
+2. **iPhone pricing change reaction** — Apple's 2023 price increase, compare to actual sales/sentiment data
+3. **Remote work policy shifts** — return-to-office mandates at major tech companies, compare to reported compliance/attrition
+
+For each:
+- [ ] Build population spec matching the real-world demographic
+- [ ] Build scenario spec matching the actual event
+- [ ] Run simulation (3x with different seeds for variance estimation)
+- [ ] Compare: outcome distribution vs. real-world survey/behavioral data
+- [ ] Metric: Spearman rank correlation on outcome ordering (target: ρ > 0.7, Aaru benchmark: 0.90)
+
+### 5.3 Convergence Testing (Run Stability)
+
+**From roadmap 4.1.** Same configuration, different random seeds → results should be similar.
+
+- [ ] Run same scenario 5x with seeds 1-5
+- [ ] Measure inter-run variance on: outcome distribution, average sentiment, average conviction
+- [ ] Pass criteria: coefficient of variation < 0.15 for all metrics
+- [ ] If variance is too high: investigate whether it's sampling variance (population generation) or reasoning variance (LLM non-determinism)
+
+### 5.4 Sensitivity Analysis
+
+**From roadmap 4.1.** Vary one parameter, check results move in expected direction.
+
+- [ ] **Price sensitivity**: same population, scenario with $10 vs $50 vs $100 price point → adoption should decrease monotonically
+- [ ] **Network density**: same population+scenario, avg_degree 2 vs 5 vs 10 → information spread rate should increase with density
+- [ ] **Population size**: 100 vs 500 vs 1000 agents → results should converge (lower inter-run variance at larger N)
+- [ ] **Timestep count**: 50 vs 100 vs 200 → outcomes should stabilize (diminishing marginal change)
+
+### 5.5 Calibration Layer (Future)
+
+**Inspired by [Koaik et al.](https://arxiv.org/abs/2601.06111)'s calibration approach.** Their per-dimension linear mapping improved RMSE from 78.32 to 25.75.
+
+This is NOT in scope for the initial validation plan, but documented as a future direction:
+- Learn a simple linear mapping: `y_real = α * y_sim + β` per outcome dimension
+- Train on historical scenarios where ground truth exists
+- Evaluate on held-out scenarios with strict temporal separation
+- Entropy's advantage: the grounding pipeline should produce agents that need less calibration than ungrounded approaches
+
+---
+
+## Part 6: Comparative & Ablation Studies
+
+Goal: understand what each component of entropy contributes to output quality.
+
+### 6.1 Two-Pass vs. Single-Pass Reasoning
+
+- [ ] Run same scenario with two-pass (current) vs. single-pass (Pass 1 only, extract position from free text)
+- [ ] Measure: central tendency metrics from 4.1
+- [ ] Expected: two-pass produces wider outcome distributions, higher conviction variance
+
+### 6.2 Network Effect Contribution
+
+- [ ] Run same population+scenario with real network vs. flat network (no edges)
+- [ ] Measure: outcome distribution delta, convergence speed, sentiment clustering
+- [ ] Expected: networked simulation shows opinion clustering by community; flat shows uniform distribution
+- [ ] This directly addresses whether entropy's temporal network simulation adds value over Aaru/Societies' single-pass approach
+
+### 6.3 Persona Richness Ablation
+
+- [ ] Full persona (PersonaConfig with z-scores, trait salience) vs. minimal persona (name + 3 demographics)
+- [ ] Measure: reasoning quality (human eval), outcome variance, segment differentiation
+- [ ] Expected: richer personas produce more differentiated, domain-specific reasoning
+
+### 6.4 Provider Comparison
+
+**From roadmap 4.4.**
+
+- [ ] Same scenario: OpenAI (gpt-5-mini) vs. Claude (haiku) for agent reasoning
+- [ ] Measure: outcome distributions, reasoning length, cost, central tendency metrics
+- [ ] This informs default provider recommendations
+
+---
+
+## Part 7: Infrastructure Required
+
+What needs to be built to execute this plan.
+
+### 7.1 Test Harness for Live Simulations
+
+A lightweight wrapper that:
+- Runs a simulation with specified config
+- Captures all outputs (results dir, SQLite state, JSONL timeline)
+- Computes validation metrics automatically
+- Supports multiple runs with different seeds
+- Outputs a structured report (JSON) for comparison
+
+### 7.2 Metric Functions
+
+New module: `entropy/validation/metrics.py` (or `tests/validation/`)
+
+```python
+def central_tendency_check(results_dir) -> dict:
+    """Check anti-central-tendency criteria."""
+
+def outcome_divergence(results_a, results_b) -> float:
+    """Jensen-Shannon divergence between two runs' outcome distributions."""
+
+def run_stability(results_dirs: list) -> dict:
+    """Coefficient of variation across multiple runs."""
+
+def segment_differentiation(results_dir, segment_attr) -> dict:
+    """Chi-squared test for outcome differences across segments."""
+
+def temporal_dynamics(results_dir) -> dict:
+    """Conviction trajectory analysis, Granger causality."""
+```
+
+### 7.3 Scenario Library
+
+Pre-built scenarios for validation testing:
+
+```
+tests/scenarios/
+├── toy_obvious_accept.yaml      # Free upgrade (sanity check)
+├── toy_obvious_reject.yaml      # Unpaid overtime (sanity check)
+├── polarizing_rto.yaml          # Return to office (splits expected)
+├── pricing_sensitivity/
+│   ├── price_10.yaml
+│   ├── price_50.yaml
+│   └── price_100.yaml
+└── historical/
+    ├── covid_mask_mandate.yaml
+    └── ...
+```
+
+### 7.4 Results Comparison Tool
+
+**From roadmap I.4.** `entropy diff results_a/ results_b/` — needed for ablation studies.
+
+---
+
+## Execution Order
+
+Sequenced by dependency and impact:
+
+| Phase | Effort | LLM Calls | Priority |
+|-------|--------|-----------|----------|
+| **1. Deterministic unit tests** (Part 1) | Low | Zero | Immediate — fills test gaps |
+| **2. Reasoning pipeline tests** (Part 2) | Low | Zero (mocked) | Immediate — validates core logic |
+| **3. Integration tests** (Part 3) | Medium | Zero (mocked) | Next — validates timestep loop |
+| **4. Anti-central-tendency** (Part 4.1) | Medium | ~5K calls | High — proves the fix works |
+| **5. LLM prior dominance** (Part 4.2) | Medium | ~10K calls | High — addresses arxiv concern |
+| **6. Toy scenarios** (Part 5.1) | Low | ~2K calls | High — basic sanity |
+| **7. Convergence testing** (Part 5.3) | Medium | ~10K calls | High — proves reliability |
+| **8. Sensitivity analysis** (Part 5.4) | Medium | ~15K calls | Medium — proves coherence |
+| **9. Historical replication** (Part 5.2) | High | ~20K calls | Medium — proves accuracy |
+| **10. Ablation studies** (Part 6) | High | ~30K calls | Lower — proves design |
+| **11. Calibration layer** (Part 5.5) | High | ~50K calls | Future — production accuracy |
+
+Parts 1-3 are pure code, no API costs. Parts 4-6 require live LLM calls. The toy scenarios (Part 5.1) are the cheapest real test and should run immediately after the unit tests pass.
+
+---
+
+## Success Criteria
+
+For entropy's simulation to be considered validated:
+
+1. **All deterministic tests pass** (Parts 1-3) — no bugs in the machinery
+2. **Central tendency fix confirmed** (Part 4.1) — all 5 criteria met
+3. **Persona sensitivity demonstrated** (Part 4.2-4.3) — JSD > 0.05 across populations, p < 0.05 across segments
+4. **Toy scenarios correct** (Part 5.1) — directional accuracy on all 4 obvious scenarios
+5. **Run stability confirmed** (Part 5.3) — CV < 0.15 across 5 seeds
+6. **Sensitivity monotonic** (Part 5.4) — price/density/size all move in expected direction
+7. **Historical replication credible** (Part 5.2) — Spearman ρ > 0.7 on at least 1 scenario
+
+If criteria 1-6 pass, entropy's simulation is mechanically sound and behaviorally reasonable. Criterion 7 is the stretch goal that proves predictive accuracy.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -341,6 +341,42 @@ def complex_population_spec() -> PopulationSpec:
 
 
 @pytest.fixture
+def ten_agents() -> list[dict]:
+    """Ten agents with varied attributes for propagation/integration tests."""
+    roles = ["junior", "mid", "senior"]
+    return [
+        {"_id": f"a{i}", "age": 25 + i * 5, "role": roles[i % 3]}
+        for i in range(10)
+    ]
+
+
+@pytest.fixture
+def linear_network() -> dict:
+    """Chain network: a0-a1-a2-...-a9."""
+    return {
+        "meta": {"node_count": 10},
+        "nodes": [{"id": f"a{i}"} for i in range(10)],
+        "edges": [
+            {"source": f"a{i}", "target": f"a{i + 1}", "type": "colleague"}
+            for i in range(9)
+        ],
+    }
+
+
+@pytest.fixture
+def star_network() -> dict:
+    """Star network: a0 is hub, a1-a9 are spokes."""
+    return {
+        "meta": {"node_count": 10},
+        "nodes": [{"id": f"a{i}"} for i in range(10)],
+        "edges": [
+            {"source": "a0", "target": f"a{i}", "type": "colleague"}
+            for i in range(1, 10)
+        ],
+    }
+
+
+@pytest.fixture
 def sample_agents() -> list[dict]:
     """Sample agent data for network tests."""
     return [

--- a/tests/test_conviction.py
+++ b/tests/test_conviction.py
@@ -1,0 +1,124 @@
+"""Tests for the conviction system.
+
+Tests conviction level mappings, float conversions, and map consistency.
+Functions under test: conviction_to_float, float_to_conviction, CONVICTION_MAP.
+"""
+
+import pytest
+
+from entropy.core.models import (
+    ConvictionLevel,
+    CONVICTION_MAP,
+    CONVICTION_REVERSE_MAP,
+    conviction_to_float,
+    float_to_conviction,
+)
+
+
+class TestConvictionToFloat:
+    """Test conviction level string → float conversion."""
+
+    @pytest.mark.parametrize(
+        "level,expected",
+        [
+            (ConvictionLevel.VERY_UNCERTAIN, 0.1),
+            (ConvictionLevel.LEANING, 0.3),
+            (ConvictionLevel.MODERATE, 0.5),
+            (ConvictionLevel.FIRM, 0.7),
+            (ConvictionLevel.ABSOLUTE, 0.9),
+        ],
+    )
+    def test_all_levels(self, level, expected):
+        assert conviction_to_float(level) == expected
+
+    def test_none_returns_none(self):
+        assert conviction_to_float(None) is None
+
+    def test_invalid_string_returns_none(self):
+        assert conviction_to_float("invalid") is None
+
+    def test_string_values_work(self):
+        """ConvictionLevel values are strings — plain strings should work too."""
+        assert conviction_to_float("very_uncertain") == 0.1
+        assert conviction_to_float("firm") == 0.7
+
+
+class TestFloatToConviction:
+    """Test float → nearest conviction level string conversion."""
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            (0.1, "very_uncertain"),
+            (0.3, "leaning"),
+            (0.5, "moderate"),
+            (0.7, "firm"),
+            (0.9, "absolute"),
+        ],
+    )
+    def test_exact_values(self, value, expected):
+        assert float_to_conviction(value) == expected
+
+    def test_none_returns_none(self):
+        assert float_to_conviction(None) is None
+
+    def test_zero_maps_to_very_uncertain(self):
+        """0.0 is closest to 0.1 (very_uncertain)."""
+        assert float_to_conviction(0.0) == "very_uncertain"
+
+    def test_one_maps_to_absolute(self):
+        """1.0 is closest to 0.9 (absolute)."""
+        assert float_to_conviction(1.0) == "absolute"
+
+    def test_midpoint_between_levels(self):
+        """0.2 is equidistant between 0.1 and 0.3 — verify it picks one."""
+        result = float_to_conviction(0.2)
+        assert result in ("very_uncertain", "leaning")
+
+    def test_just_above_boundary(self):
+        """0.41 should map to moderate (0.5) not leaning (0.3)."""
+        assert float_to_conviction(0.41) == "moderate"
+
+    def test_just_below_boundary(self):
+        """0.59 should map to moderate (0.5) not firm (0.7)."""
+        assert float_to_conviction(0.59) == "moderate"
+
+
+class TestConvictionMaps:
+    """Test CONVICTION_MAP and CONVICTION_REVERSE_MAP consistency."""
+
+    def test_map_has_five_levels(self):
+        assert len(CONVICTION_MAP) == 5
+
+    def test_reverse_map_has_five_levels(self):
+        assert len(CONVICTION_REVERSE_MAP) == 5
+
+    def test_roundtrip_forward_reverse(self):
+        """Every key in CONVICTION_MAP appears as value in CONVICTION_REVERSE_MAP."""
+        for level, value in CONVICTION_MAP.items():
+            assert CONVICTION_REVERSE_MAP[value] == level
+
+    def test_roundtrip_reverse_forward(self):
+        """Every key in CONVICTION_REVERSE_MAP appears as value in CONVICTION_MAP."""
+        for value, level in CONVICTION_REVERSE_MAP.items():
+            assert CONVICTION_MAP[level] == value
+
+    def test_values_are_ordered(self):
+        """Float values increase with conviction level severity."""
+        assert (
+            CONVICTION_MAP[ConvictionLevel.VERY_UNCERTAIN]
+            < CONVICTION_MAP[ConvictionLevel.LEANING]
+            < CONVICTION_MAP[ConvictionLevel.MODERATE]
+            < CONVICTION_MAP[ConvictionLevel.FIRM]
+            < CONVICTION_MAP[ConvictionLevel.ABSOLUTE]
+        )
+
+    def test_values_in_zero_one_range(self):
+        """All conviction floats are in (0, 1)."""
+        for value in CONVICTION_MAP.values():
+            assert 0 < value < 1
+
+    def test_all_enum_members_in_map(self):
+        """Every ConvictionLevel enum member has a mapping."""
+        for level in ConvictionLevel:
+            assert level in CONVICTION_MAP

--- a/tests/test_integration_timestep.py
+++ b/tests/test_integration_timestep.py
@@ -1,0 +1,653 @@
+"""Integration tests for the simulation engine timestep loop.
+
+Tests the full timestep cycle (exposure → reasoning → state update)
+and multi-timestep dynamics with mocked LLM calls. No real API calls.
+Functions under test in entropy/simulation/engine.py.
+"""
+
+from datetime import datetime
+from unittest.mock import patch
+
+import pytest
+
+from entropy.core.models import (
+    AgentState,
+    ConvictionLevel,
+    CONVICTION_MAP,
+    ExposureRecord,
+    ReasoningResponse,
+    SimulationRunConfig,
+)
+from entropy.core.models.scenario import (
+    Event,
+    EventType,
+    ExposureChannel,
+    ExposureRule,
+    InteractionConfig,
+    InteractionType,
+    OutcomeConfig,
+    OutcomeDefinition,
+    OutcomeType,
+    ScenarioMeta,
+    ScenarioSpec,
+    SeedExposure,
+    SimulationConfig,
+    SpreadConfig,
+    TimestepUnit,
+)
+from entropy.simulation.engine import SimulationEngine
+
+
+def _make_reasoning_response(**kwargs) -> ReasoningResponse:
+    """Helper to create a ReasoningResponse with sensible defaults."""
+    defaults = {
+        "position": "adopt",
+        "sentiment": 0.5,
+        "conviction": CONVICTION_MAP[ConvictionLevel.MODERATE],
+        "public_statement": "I think this is good.",
+        "reasoning_summary": "Positive initial reaction.",
+        "action_intent": "Will try it",
+        "will_share": True,
+        "reasoning": "I considered the product and find it appealing.",
+        "outcomes": {"adoption": "adopt"},
+    }
+    defaults.update(kwargs)
+    return ReasoningResponse(**defaults)
+
+
+def _make_scenario(
+    max_timesteps=10,
+    rules=None,
+    share_probability=1.0,
+    stop_conditions=None,
+):
+    """Create a configurable scenario for engine tests."""
+    if rules is None:
+        rules = [
+            ExposureRule(
+                channel="broadcast",
+                timestep=0,
+                when="true",
+                probability=1.0,
+            ),
+        ]
+    return ScenarioSpec(
+        meta=ScenarioMeta(
+            name="test_scenario",
+            description="Test scenario",
+            population_spec="test.yaml",
+            agents_file="test.json",
+            network_file="test_network.json",
+            created_at=datetime(2024, 1, 1),
+        ),
+        event=Event(
+            type=EventType.PRODUCT_LAUNCH,
+            content="A new product is launching.",
+            source="Test Corp",
+            credibility=0.9,
+            ambiguity=0.2,
+            emotional_valence=0.3,
+        ),
+        seed_exposure=SeedExposure(
+            channels=[
+                ExposureChannel(
+                    name="broadcast",
+                    description="Broadcast",
+                    reach="broadcast",
+                    credibility_modifier=1.0,
+                ),
+            ],
+            rules=rules,
+        ),
+        interaction=InteractionConfig(
+            primary_model=InteractionType.PASSIVE_OBSERVATION,
+            description="Observe",
+        ),
+        spread=SpreadConfig(share_probability=share_probability),
+        outcomes=OutcomeConfig(
+            suggested_outcomes=[
+                OutcomeDefinition(
+                    name="adoption",
+                    description="Adoption decision",
+                    type=OutcomeType.CATEGORICAL,
+                    required=True,
+                    options=["adopt", "reject", "undecided"],
+                ),
+            ],
+        ),
+        simulation=SimulationConfig(
+            max_timesteps=max_timesteps,
+            timestep_unit=TimestepUnit.HOUR,
+            stop_conditions=stop_conditions,
+        ),
+    )
+
+
+def _make_engine(scenario, agents, network, tmp_path):
+    """Create a SimulationEngine with the given parameters."""
+    config = SimulationRunConfig(
+        scenario_path="test.yaml",
+        output_dir=str(tmp_path / "output"),
+        random_seed=42,
+    )
+    return SimulationEngine(
+        scenario=scenario,
+        population_spec=pytest.importorskip(
+            "tests.conftest"
+        ).minimal_population_spec
+        if False
+        else _minimal_pop_spec(),
+        agents=agents,
+        network=network,
+        config=config,
+    )
+
+
+def _minimal_pop_spec():
+    """Inline minimal population spec to avoid fixture dependency."""
+    from entropy.core.models.population import (
+        AttributeSpec,
+        CategoricalDistribution,
+        GroundingInfo,
+        GroundingSummary,
+        NormalDistribution,
+        PopulationSpec,
+        SamplingConfig,
+        SpecMeta,
+    )
+
+    return PopulationSpec(
+        meta=SpecMeta(
+            description="Test population",
+            size=100,
+            geography="Test Region",
+            created_at=datetime(2024, 1, 1),
+            version="1.0",
+        ),
+        grounding=GroundingSummary(
+            overall="medium",
+            sources_count=0,
+            strong_count=0,
+            medium_count=2,
+            low_count=0,
+            sources=[],
+        ),
+        attributes=[
+            AttributeSpec(
+                name="age",
+                type="int",
+                category="universal",
+                description="Age",
+                sampling=SamplingConfig(
+                    strategy="independent",
+                    distribution=NormalDistribution(
+                        type="normal", mean=45.0, std=10.0, min=25.0, max=70.0
+                    ),
+                ),
+                grounding=GroundingInfo(level="medium", method="estimated"),
+            ),
+        ],
+        sampling_order=["age"],
+    )
+
+
+def _mock_batch_reason(responses_map=None, default_response=None):
+    """Create a mock for batch_reason_agents that returns canned responses.
+
+    Args:
+        responses_map: Optional dict of agent_id → ReasoningResponse
+        default_response: Fallback response for agents not in responses_map
+    """
+    if default_response is None:
+        default_response = _make_reasoning_response()
+
+    def mock_fn(contexts, scenario, config, **kwargs):
+        results = []
+        for ctx in contexts:
+            if responses_map and ctx.agent_id in responses_map:
+                results.append((ctx.agent_id, responses_map[ctx.agent_id]))
+            else:
+                results.append((ctx.agent_id, default_response))
+        return results
+
+    return mock_fn
+
+
+# ============================================================================
+# Engine Initialization
+# ============================================================================
+
+
+class TestEngineInit:
+    """Test engine initialization."""
+
+    def test_adjacency_not_used_in_engine_propagation(
+        self, ten_agents, linear_network, tmp_path
+    ):
+        """Engine builds agent_map from agents list."""
+        scenario = _make_scenario()
+        config = SimulationRunConfig(
+            scenario_path="test.yaml",
+            output_dir=str(tmp_path / "output"),
+        )
+        engine = SimulationEngine(
+            scenario=scenario,
+            population_spec=_minimal_pop_spec(),
+            agents=ten_agents,
+            network=linear_network,
+            config=config,
+        )
+
+        assert "a0" in engine.agent_map
+        assert "a9" in engine.agent_map
+        assert len(engine.agent_map) == 10
+
+    def test_personas_pre_generated(self, ten_agents, linear_network, tmp_path):
+        """All agents get personas at init time."""
+        scenario = _make_scenario()
+        config = SimulationRunConfig(
+            scenario_path="test.yaml",
+            output_dir=str(tmp_path / "output"),
+        )
+        engine = SimulationEngine(
+            scenario=scenario,
+            population_spec=_minimal_pop_spec(),
+            agents=ten_agents,
+            network=linear_network,
+            config=config,
+        )
+
+        assert len(engine._personas) == 10
+        for i in range(10):
+            assert f"a{i}" in engine._personas
+            assert len(engine._personas[f"a{i}"]) > 0
+
+
+# ============================================================================
+# Single Timestep
+# ============================================================================
+
+
+class TestSingleTimestep:
+    """Test a single timestep execution with mocked LLM."""
+
+    @patch("entropy.simulation.engine.batch_reason_agents")
+    def test_seed_exposure_then_reasoning(
+        self, mock_batch, ten_agents, linear_network, tmp_path
+    ):
+        """Timestep 0: seed exposure → agents reason → state updated."""
+        mock_batch.side_effect = _mock_batch_reason()
+        scenario = _make_scenario(max_timesteps=5)
+        config = SimulationRunConfig(
+            scenario_path="test.yaml",
+            output_dir=str(tmp_path / "output"),
+            random_seed=42,
+        )
+        engine = SimulationEngine(
+            scenario=scenario,
+            population_spec=_minimal_pop_spec(),
+            agents=ten_agents,
+            network=linear_network,
+            config=config,
+        )
+
+        summary = engine._run_timestep(0)
+
+        # All 10 agents exposed at timestep 0 (broadcast, prob=1.0)
+        assert summary.new_exposures == 10
+        assert summary.agents_reasoned == 10
+
+        # All agents should now have position and sentiment
+        for i in range(10):
+            state = engine.state_manager.get_agent_state(f"a{i}")
+            assert state.aware is True
+            assert state.position == "adopt"
+            assert state.sentiment == 0.5
+
+    @patch("entropy.simulation.engine.batch_reason_agents")
+    def test_no_reasoning_without_exposure(
+        self, mock_batch, ten_agents, linear_network, tmp_path
+    ):
+        """Timestep with no exposure rules → no reasoning."""
+        mock_batch.return_value = []
+        # Rules only at timestep=5, running timestep=0
+        rules = [
+            ExposureRule(
+                channel="broadcast", timestep=5, when="true", probability=1.0
+            ),
+        ]
+        scenario = _make_scenario(max_timesteps=10, rules=rules)
+        config = SimulationRunConfig(
+            scenario_path="test.yaml",
+            output_dir=str(tmp_path / "output"),
+            random_seed=42,
+        )
+        engine = SimulationEngine(
+            scenario=scenario,
+            population_spec=_minimal_pop_spec(),
+            agents=ten_agents,
+            network=linear_network,
+            config=config,
+        )
+
+        summary = engine._run_timestep(0)
+
+        assert summary.new_exposures == 0
+        assert summary.agents_reasoned == 0
+        # batch_reason_agents is called with empty contexts list
+        mock_batch.assert_called_once()
+        contexts_arg = mock_batch.call_args[0][0]
+        assert contexts_arg == []
+
+    @patch("entropy.simulation.engine.batch_reason_agents")
+    def test_memory_entry_saved(
+        self, mock_batch, ten_agents, linear_network, tmp_path
+    ):
+        """Reasoning produces a memory entry for each agent."""
+        mock_batch.side_effect = _mock_batch_reason()
+        scenario = _make_scenario(max_timesteps=5)
+        config = SimulationRunConfig(
+            scenario_path="test.yaml",
+            output_dir=str(tmp_path / "output"),
+            random_seed=42,
+        )
+        engine = SimulationEngine(
+            scenario=scenario,
+            population_spec=_minimal_pop_spec(),
+            agents=ten_agents,
+            network=linear_network,
+            config=config,
+        )
+
+        engine._run_timestep(0)
+
+        traces = engine.state_manager.get_memory_traces("a0")
+        assert len(traces) == 1
+        assert traces[0].summary == "Positive initial reaction."
+
+    @patch("entropy.simulation.engine.batch_reason_agents")
+    def test_flip_resistance_applied(
+        self, mock_batch, ten_agents, linear_network, tmp_path
+    ):
+        """Firm agent with weak new conviction → position flip rejected."""
+        scenario = _make_scenario(max_timesteps=5)
+        config = SimulationRunConfig(
+            scenario_path="test.yaml",
+            output_dir=str(tmp_path / "output"),
+            random_seed=42,
+        )
+        engine = SimulationEngine(
+            scenario=scenario,
+            population_spec=_minimal_pop_spec(),
+            agents=ten_agents,
+            network=linear_network,
+            config=config,
+        )
+
+        # Manually set a0 to firm conviction with "adopt" position
+        engine.state_manager.record_exposure(
+            "a0",
+            ExposureRecord(
+                timestep=0, channel="broadcast", content="test", credibility=0.9
+            ),
+        )
+        engine.state_manager.update_agent_state(
+            "a0",
+            AgentState(
+                agent_id="a0",
+                aware=True,
+                position="adopt",
+                conviction=CONVICTION_MAP[ConvictionLevel.FIRM],
+                sentiment=0.5,
+            ),
+            timestep=0,
+        )
+
+        # Mock: a0 tries to flip to "reject" with very_uncertain conviction
+        mock_batch.side_effect = _mock_batch_reason(
+            responses_map={
+                "a0": _make_reasoning_response(
+                    position="reject",
+                    conviction=CONVICTION_MAP[ConvictionLevel.VERY_UNCERTAIN],
+                    will_share=True,
+                ),
+            }
+        )
+
+        # Need to give a0 enough new exposures to trigger re-reasoning
+        for t in range(1, 5):
+            engine.state_manager.record_exposure(
+                "a0",
+                ExposureRecord(
+                    timestep=t, channel="network", content="test",
+                    credibility=0.85, source_agent_id=f"a{t}",
+                ),
+            )
+
+        engine._run_timestep(1)
+
+        state = engine.state_manager.get_agent_state("a0")
+        # Flip rejected — kept old position
+        assert state.position == "adopt"
+        # But sharing also gated because conviction is very_uncertain
+        assert state.will_share is False
+
+    @patch("entropy.simulation.engine.batch_reason_agents")
+    def test_conviction_gated_sharing(
+        self, mock_batch, ten_agents, linear_network, tmp_path
+    ):
+        """Very uncertain agent gets will_share forced to False."""
+        mock_batch.side_effect = _mock_batch_reason(
+            default_response=_make_reasoning_response(
+                conviction=CONVICTION_MAP[ConvictionLevel.VERY_UNCERTAIN],
+                will_share=True,  # Agent wants to share but conviction too low
+            )
+        )
+        scenario = _make_scenario(max_timesteps=5)
+        config = SimulationRunConfig(
+            scenario_path="test.yaml",
+            output_dir=str(tmp_path / "output"),
+            random_seed=42,
+        )
+        engine = SimulationEngine(
+            scenario=scenario,
+            population_spec=_minimal_pop_spec(),
+            agents=ten_agents,
+            network=linear_network,
+            config=config,
+        )
+
+        engine._run_timestep(0)
+
+        for i in range(10):
+            state = engine.state_manager.get_agent_state(f"a{i}")
+            assert state.will_share is False  # gated by low conviction
+
+
+# ============================================================================
+# Multi-Timestep Dynamics
+# ============================================================================
+
+
+class TestMultiTimestepDynamics:
+    """Test multi-timestep simulation behavior."""
+
+    @patch("entropy.simulation.engine.batch_reason_agents")
+    def test_information_cascade_through_chain(
+        self, mock_batch, ten_agents, linear_network, tmp_path
+    ):
+        """Information propagates through chain network over timesteps.
+
+        a0 exposed at t=0, shares to a1 at t=1, a1 shares to a2 at t=2, etc.
+        """
+        mock_batch.side_effect = _mock_batch_reason(
+            default_response=_make_reasoning_response(
+                will_share=True,
+                conviction=CONVICTION_MAP[ConvictionLevel.MODERATE],
+            )
+        )
+
+        # Only seed a0 at timestep 0
+        rules = [
+            ExposureRule(
+                channel="broadcast",
+                timestep=0,
+                when="_id == 'a0'",
+                probability=1.0,
+            ),
+        ]
+        scenario = _make_scenario(
+            max_timesteps=12,
+            rules=rules,
+            share_probability=1.0,
+        )
+        config = SimulationRunConfig(
+            scenario_path="test.yaml",
+            output_dir=str(tmp_path / "output"),
+            random_seed=42,
+        )
+        engine = SimulationEngine(
+            scenario=scenario,
+            population_spec=_minimal_pop_spec(),
+            agents=ten_agents,
+            network=linear_network,
+            config=config,
+        )
+
+        # Run several timesteps
+        for t in range(6):
+            engine._run_timestep(t)
+
+        # After 6 timesteps in a chain, information should have reached
+        # several hops from a0
+        a0_state = engine.state_manager.get_agent_state("a0")
+        assert a0_state.aware is True
+
+        a1_state = engine.state_manager.get_agent_state("a1")
+        assert a1_state.aware is True
+
+        # Verify exposure rate is increasing
+        rate = engine.state_manager.get_exposure_rate()
+        assert rate > 0.1  # At minimum a0 and a1 are aware
+
+    @patch("entropy.simulation.engine.batch_reason_agents")
+    def test_stopping_condition_triggers(
+        self, mock_batch, ten_agents, star_network, tmp_path
+    ):
+        """Simulation stops early when stop condition is met."""
+        mock_batch.side_effect = _mock_batch_reason(
+            default_response=_make_reasoning_response(
+                will_share=True,
+                conviction=CONVICTION_MAP[ConvictionLevel.MODERATE],
+            )
+        )
+
+        scenario = _make_scenario(
+            max_timesteps=50,
+            share_probability=1.0,
+            stop_conditions=["exposure_rate > 0.5"],
+        )
+        config = SimulationRunConfig(
+            scenario_path="test.yaml",
+            output_dir=str(tmp_path / "output"),
+            random_seed=42,
+        )
+        engine = SimulationEngine(
+            scenario=scenario,
+            population_spec=_minimal_pop_spec(),
+            agents=ten_agents,
+            network=star_network,
+            config=config,
+        )
+
+        result = engine.run()
+
+        # Should have stopped before max_timesteps
+        assert result.total_timesteps < 50
+        assert result.stopped_reason is not None
+
+    @patch("entropy.simulation.engine.batch_reason_agents")
+    def test_isolated_agent_never_exposed(
+        self, mock_batch, tmp_path
+    ):
+        """Agent with no network edges never gets network exposure."""
+        mock_batch.side_effect = _mock_batch_reason(
+            default_response=_make_reasoning_response(will_share=True)
+        )
+
+        agents = [
+            {"_id": "a0", "age": 30, "role": "junior"},
+            {"_id": "a1", "age": 40, "role": "senior"},
+            {"_id": "isolated", "age": 50, "role": "mid"},
+        ]
+        network = {
+            "meta": {"node_count": 3},
+            "nodes": [{"id": "a0"}, {"id": "a1"}, {"id": "isolated"}],
+            "edges": [{"source": "a0", "target": "a1", "type": "colleague"}],
+        }
+
+        # Only expose a0
+        rules = [
+            ExposureRule(
+                channel="broadcast",
+                timestep=0,
+                when="_id == 'a0'",
+                probability=1.0,
+            ),
+        ]
+        scenario = _make_scenario(
+            max_timesteps=5,
+            rules=rules,
+            share_probability=1.0,
+        )
+        config = SimulationRunConfig(
+            scenario_path="test.yaml",
+            output_dir=str(tmp_path / "output"),
+            random_seed=42,
+        )
+        engine = SimulationEngine(
+            scenario=scenario,
+            population_spec=_minimal_pop_spec(),
+            agents=agents,
+            network=network,
+            config=config,
+        )
+
+        for t in range(5):
+            engine._run_timestep(t)
+
+        iso_state = engine.state_manager.get_agent_state("isolated")
+        assert iso_state.aware is False
+
+    @patch("entropy.simulation.engine.batch_reason_agents")
+    def test_exposure_rate_never_decreases(
+        self, mock_batch, ten_agents, star_network, tmp_path
+    ):
+        """Exposure rate should be monotonically non-decreasing."""
+        mock_batch.side_effect = _mock_batch_reason(
+            default_response=_make_reasoning_response(
+                will_share=True,
+                conviction=CONVICTION_MAP[ConvictionLevel.MODERATE],
+            )
+        )
+
+        scenario = _make_scenario(max_timesteps=8, share_probability=1.0)
+        config = SimulationRunConfig(
+            scenario_path="test.yaml",
+            output_dir=str(tmp_path / "output"),
+            random_seed=42,
+        )
+        engine = SimulationEngine(
+            scenario=scenario,
+            population_spec=_minimal_pop_spec(),
+            agents=ten_agents,
+            network=star_network,
+            config=config,
+        )
+
+        prev_rate = 0.0
+        for t in range(5):
+            engine._run_timestep(t)
+            rate = engine.state_manager.get_exposure_rate()
+            assert rate >= prev_rate
+            prev_rate = rate

--- a/tests/test_memory_traces.py
+++ b/tests/test_memory_traces.py
@@ -1,0 +1,311 @@
+"""Tests for memory trace management and multi-touch reasoning triggers.
+
+Tests the sliding window memory trace (max 3 entries per agent),
+the get_agents_to_reason multi-touch logic, and aggregation queries.
+Functions under test in entropy/simulation/state.py.
+"""
+
+import pytest
+
+from entropy.core.models import (
+    AgentState,
+    ExposureRecord,
+    MemoryEntry,
+)
+from entropy.simulation.state import StateManager
+
+
+def _make_exposure(timestep=0, channel="broadcast"):
+    """Factory for ExposureRecord."""
+    return ExposureRecord(
+        timestep=timestep,
+        channel=channel,
+        content="test content",
+        credibility=0.9,
+    )
+
+
+def _make_memory(timestep=0, sentiment=0.5, conviction=0.5, summary="Test thought"):
+    """Factory for MemoryEntry."""
+    return MemoryEntry(
+        timestep=timestep,
+        sentiment=sentiment,
+        conviction=conviction,
+        summary=summary,
+    )
+
+
+@pytest.fixture
+def five_agents():
+    return [{"_id": f"a{i}"} for i in range(5)]
+
+
+@pytest.fixture
+def state_mgr(tmp_path, five_agents):
+    """StateManager with 5 initialized agents."""
+    return StateManager(tmp_path / "test.db", agents=five_agents)
+
+
+# ============================================================================
+# Memory Trace Sliding Window
+# ============================================================================
+
+
+class TestMemoryTraceWindow:
+    """Test save_memory_entry and get_memory_traces sliding window."""
+
+    def test_single_entry(self, state_mgr):
+        state_mgr.save_memory_entry("a0", _make_memory(timestep=0))
+
+        traces = state_mgr.get_memory_traces("a0")
+        assert len(traces) == 1
+        assert traces[0].timestep == 0
+
+    def test_three_entries_retained(self, state_mgr):
+        for t in range(3):
+            state_mgr.save_memory_entry(
+                "a0", _make_memory(timestep=t, summary=f"thought_{t}")
+            )
+
+        traces = state_mgr.get_memory_traces("a0")
+        assert len(traces) == 3
+        # Ordered oldest first
+        assert traces[0].timestep == 0
+        assert traces[2].timestep == 2
+
+    def test_fourth_entry_evicts_oldest(self, state_mgr):
+        """After 4 inserts, only the latest 3 remain."""
+        for t in range(4):
+            state_mgr.save_memory_entry(
+                "a0", _make_memory(timestep=t, summary=f"thought_{t}")
+            )
+
+        traces = state_mgr.get_memory_traces("a0")
+        assert len(traces) == 3
+        # Oldest (t=0) evicted
+        assert traces[0].timestep == 1
+        assert traces[1].timestep == 2
+        assert traces[2].timestep == 3
+
+    def test_fifth_entry_still_three(self, state_mgr):
+        """After 5 inserts, still only 3 traces."""
+        for t in range(5):
+            state_mgr.save_memory_entry(
+                "a0", _make_memory(timestep=t, summary=f"thought_{t}")
+            )
+
+        traces = state_mgr.get_memory_traces("a0")
+        assert len(traces) == 3
+        assert traces[0].timestep == 2
+        assert traces[2].timestep == 4
+
+    def test_separate_agents_independent(self, state_mgr):
+        """Each agent has its own independent memory trace."""
+        for t in range(4):
+            state_mgr.save_memory_entry("a0", _make_memory(timestep=t))
+        state_mgr.save_memory_entry("a1", _make_memory(timestep=10))
+
+        assert len(state_mgr.get_memory_traces("a0")) == 3
+        assert len(state_mgr.get_memory_traces("a1")) == 1
+
+    def test_no_traces_for_new_agent(self, state_mgr):
+        traces = state_mgr.get_memory_traces("a0")
+        assert len(traces) == 0
+
+    def test_memory_preserves_content(self, state_mgr):
+        state_mgr.save_memory_entry(
+            "a0",
+            _make_memory(
+                timestep=5, sentiment=-0.3, conviction=0.7, summary="I'm skeptical"
+            ),
+        )
+
+        traces = state_mgr.get_memory_traces("a0")
+        assert traces[0].sentiment == pytest.approx(-0.3)
+        assert traces[0].conviction == pytest.approx(0.7)
+        assert traces[0].summary == "I'm skeptical"
+
+
+# ============================================================================
+# Multi-Touch Reasoning Triggers
+# ============================================================================
+
+
+class TestGetAgentsToReason:
+    """Test get_agents_to_reason(timestep, threshold) multi-touch logic."""
+
+    def test_never_reasoned_aware_agent(self, state_mgr):
+        """Aware agent who never reasoned should be in the list."""
+        state_mgr.record_exposure("a0", _make_exposure(timestep=0))
+
+        agents = state_mgr.get_agents_to_reason(timestep=0, threshold=3)
+        assert "a0" in agents
+
+    def test_unaware_agent_excluded(self, state_mgr):
+        """Agent without exposure should not be in the list."""
+        agents = state_mgr.get_agents_to_reason(timestep=0, threshold=3)
+        assert "a0" not in agents
+
+    def test_multi_touch_below_threshold(self, state_mgr):
+        """Agent who reasoned and got < threshold new exposures → excluded."""
+        # Make aware and reason
+        state_mgr.record_exposure("a0", _make_exposure(timestep=0))
+        state_mgr.update_agent_state(
+            "a0",
+            AgentState(
+                agent_id="a0", aware=True, position="adopt",
+                sentiment=0.5, conviction=0.5,
+            ),
+            timestep=0,
+        )
+
+        # Add 2 new exposures (threshold is 3)
+        state_mgr.record_exposure("a0", _make_exposure(timestep=1))
+        state_mgr.record_exposure("a0", _make_exposure(timestep=2))
+
+        agents = state_mgr.get_agents_to_reason(timestep=2, threshold=3)
+        assert "a0" not in agents
+
+    def test_multi_touch_at_threshold(self, state_mgr):
+        """Agent who reasoned and got exactly threshold new exposures → included."""
+        state_mgr.record_exposure("a0", _make_exposure(timestep=0))
+        state_mgr.update_agent_state(
+            "a0",
+            AgentState(
+                agent_id="a0", aware=True, position="adopt",
+                sentiment=0.5, conviction=0.5,
+            ),
+            timestep=0,
+        )
+
+        # Add 3 new exposures (threshold is 3)
+        state_mgr.record_exposure("a0", _make_exposure(timestep=1))
+        state_mgr.record_exposure("a0", _make_exposure(timestep=2))
+        state_mgr.record_exposure("a0", _make_exposure(timestep=3))
+
+        agents = state_mgr.get_agents_to_reason(timestep=3, threshold=3)
+        assert "a0" in agents
+
+    def test_multi_touch_above_threshold(self, state_mgr):
+        """Agent who reasoned and got > threshold new exposures → included."""
+        state_mgr.record_exposure("a0", _make_exposure(timestep=0))
+        state_mgr.update_agent_state(
+            "a0",
+            AgentState(
+                agent_id="a0", aware=True, position="adopt",
+                sentiment=0.5, conviction=0.5,
+            ),
+            timestep=0,
+        )
+
+        # Add 5 new exposures
+        for t in range(1, 6):
+            state_mgr.record_exposure("a0", _make_exposure(timestep=t))
+
+        agents = state_mgr.get_agents_to_reason(timestep=5, threshold=3)
+        assert "a0" in agents
+
+    def test_recently_reasoned_no_new_exposures(self, state_mgr):
+        """Agent who reasoned recently with no new exposures → excluded."""
+        state_mgr.record_exposure("a0", _make_exposure(timestep=0))
+        state_mgr.update_agent_state(
+            "a0",
+            AgentState(
+                agent_id="a0", aware=True, position="adopt",
+                sentiment=0.5, conviction=0.5,
+            ),
+            timestep=5,
+        )
+
+        agents = state_mgr.get_agents_to_reason(timestep=6, threshold=3)
+        assert "a0" not in agents
+
+    def test_multiple_agents_mixed(self, state_mgr):
+        """Test with multiple agents in different states."""
+        # a0: aware, never reasoned → should reason
+        state_mgr.record_exposure("a0", _make_exposure(timestep=0))
+
+        # a1: reasoned, 3 new exposures → should reason (multi-touch)
+        state_mgr.record_exposure("a1", _make_exposure(timestep=0))
+        state_mgr.update_agent_state(
+            "a1",
+            AgentState(agent_id="a1", aware=True, position="adopt",
+                       sentiment=0.5, conviction=0.5),
+            timestep=0,
+        )
+        for t in range(1, 4):
+            state_mgr.record_exposure("a1", _make_exposure(timestep=t))
+
+        # a2: not aware → should not reason
+        # a3: reasoned, only 1 new exposure → should not reason
+        state_mgr.record_exposure("a3", _make_exposure(timestep=0))
+        state_mgr.update_agent_state(
+            "a3",
+            AgentState(agent_id="a3", aware=True, position="reject",
+                       sentiment=-0.3, conviction=0.7),
+            timestep=0,
+        )
+        state_mgr.record_exposure("a3", _make_exposure(timestep=1))
+
+        agents = state_mgr.get_agents_to_reason(timestep=3, threshold=3)
+        assert "a0" in agents
+        assert "a1" in agents
+        assert "a2" not in agents
+        assert "a3" not in agents
+
+
+# ============================================================================
+# Aggregation Queries
+# ============================================================================
+
+
+class TestAggregationQueries:
+    """Test analytics queries on StateManager."""
+
+    def test_get_sentiment_variance(self, state_mgr):
+        """Variance of [0.1, 0.3, 0.5, 0.7, 0.9] = 0.08."""
+        sentiments = [0.1, 0.3, 0.5, 0.7, 0.9]
+        for i, s in enumerate(sentiments):
+            state_mgr.record_exposure(f"a{i}", _make_exposure(timestep=0))
+            state_mgr.update_agent_state(
+                f"a{i}",
+                AgentState(agent_id=f"a{i}", sentiment=s, conviction=0.5),
+                timestep=0,
+            )
+
+        variance = state_mgr.get_sentiment_variance()
+        # mean = 0.5, variance = ((0.4^2 + 0.2^2 + 0 + 0.2^2 + 0.4^2) / 5) = 0.08
+        assert variance == pytest.approx(0.08, abs=0.001)
+
+    def test_get_sentiment_variance_none_when_no_data(self, state_mgr):
+        """No agents with sentiment → None."""
+        variance = state_mgr.get_sentiment_variance()
+        assert variance is None
+
+    def test_get_average_conviction(self, state_mgr):
+        convictions = [0.1, 0.3, 0.5, 0.7, 0.9]
+        for i, c in enumerate(convictions):
+            state_mgr.record_exposure(f"a{i}", _make_exposure(timestep=0))
+            state_mgr.update_agent_state(
+                f"a{i}",
+                AgentState(agent_id=f"a{i}", sentiment=0.0, conviction=c),
+                timestep=0,
+            )
+
+        avg = state_mgr.get_average_conviction()
+        assert avg == pytest.approx(0.5)
+
+    def test_get_population_count(self, state_mgr):
+        assert state_mgr.get_population_count() == 5
+
+    def test_get_exposure_rate(self, state_mgr):
+        """3 out of 5 agents aware → 0.6."""
+        for i in range(3):
+            state_mgr.record_exposure(f"a{i}", _make_exposure(timestep=0))
+
+        rate = state_mgr.get_exposure_rate()
+        assert rate == pytest.approx(0.6)
+
+    def test_get_exposure_rate_zero(self, state_mgr):
+        """No aware agents → 0.0."""
+        assert state_mgr.get_exposure_rate() == 0.0

--- a/tests/test_propagation.py
+++ b/tests/test_propagation.py
@@ -1,0 +1,578 @@
+"""Tests for exposure propagation and network spreading.
+
+Tests seed exposure application, network propagation, share probability
+calculation, and credibility assignments.
+Functions under test in entropy/simulation/propagation.py.
+"""
+
+import random
+from datetime import datetime
+
+import pytest
+
+from entropy.core.models import AgentState, ExposureRecord
+from entropy.core.models.scenario import (
+    Event,
+    EventType,
+    ExposureChannel,
+    ExposureRule,
+    InteractionConfig,
+    InteractionType,
+    OutcomeConfig,
+    OutcomeDefinition,
+    OutcomeType,
+    ScenarioMeta,
+    ScenarioSpec,
+    SeedExposure,
+    SimulationConfig,
+    SpreadConfig,
+    SpreadModifier,
+    TimestepUnit,
+)
+from entropy.simulation.propagation import (
+    apply_seed_exposures,
+    calculate_share_probability,
+    evaluate_exposure_rule,
+    get_channel_credibility,
+    get_neighbors,
+    propagate_through_network,
+)
+from entropy.simulation.state import StateManager
+
+
+def _make_scenario(
+    rules=None,
+    channels=None,
+    event_credibility=0.9,
+    share_probability=0.3,
+    share_modifiers=None,
+):
+    """Create a scenario with configurable exposure rules and spread config."""
+    if channels is None:
+        channels = [
+            ExposureChannel(
+                name="broadcast",
+                description="Mass broadcast",
+                reach="broadcast",
+                credibility_modifier=1.0,
+            ),
+        ]
+    if rules is None:
+        rules = [
+            ExposureRule(
+                channel="broadcast",
+                timestep=0,
+                when="true",
+                probability=1.0,
+            ),
+        ]
+
+    return ScenarioSpec(
+        meta=ScenarioMeta(
+            name="test",
+            description="Test scenario",
+            population_spec="test.yaml",
+            agents_file="test.json",
+            network_file="test_network.json",
+            created_at=datetime(2024, 1, 1),
+        ),
+        event=Event(
+            type=EventType.PRODUCT_LAUNCH,
+            content="A new product is launching.",
+            source="Test Corp",
+            credibility=event_credibility,
+            ambiguity=0.2,
+            emotional_valence=0.3,
+        ),
+        seed_exposure=SeedExposure(channels=channels, rules=rules),
+        interaction=InteractionConfig(
+            primary_model=InteractionType.PASSIVE_OBSERVATION,
+            description="Observe",
+        ),
+        spread=SpreadConfig(
+            share_probability=share_probability,
+            share_modifiers=share_modifiers or [],
+        ),
+        outcomes=OutcomeConfig(
+            suggested_outcomes=[
+                OutcomeDefinition(
+                    name="adoption",
+                    description="Adoption decision",
+                    type=OutcomeType.CATEGORICAL,
+                    required=True,
+                    options=["adopt", "reject", "undecided"],
+                ),
+            ],
+        ),
+        simulation=SimulationConfig(max_timesteps=5, timestep_unit=TimestepUnit.HOUR),
+    )
+
+
+# ============================================================================
+# Exposure Rule Evaluation
+# ============================================================================
+
+
+class TestEvaluateExposureRule:
+    """Test evaluate_exposure_rule(rule, agent, timestep)."""
+
+    def test_matching_timestep_and_true_condition(self):
+        rule = ExposureRule(channel="broadcast", timestep=0, when="true", probability=1.0)
+        agent = {"_id": "a0", "age": 30}
+        assert evaluate_exposure_rule(rule, agent, 0) is True
+
+    def test_wrong_timestep(self):
+        rule = ExposureRule(channel="broadcast", timestep=0, when="true", probability=1.0)
+        agent = {"_id": "a0", "age": 30}
+        assert evaluate_exposure_rule(rule, agent, 1) is False
+
+    def test_condition_filters_agent(self):
+        rule = ExposureRule(
+            channel="broadcast", timestep=0, when="age > 40", probability=1.0
+        )
+        agent = {"_id": "a0", "age": 30}
+        assert evaluate_exposure_rule(rule, agent, 0) is False
+
+    def test_condition_matches_agent(self):
+        rule = ExposureRule(
+            channel="broadcast", timestep=0, when="age > 40", probability=1.0
+        )
+        agent = {"_id": "a0", "age": 50}
+        assert evaluate_exposure_rule(rule, agent, 0) is True
+
+    def test_numeric_true_condition(self):
+        """when='1' should also be treated as always true."""
+        rule = ExposureRule(channel="broadcast", timestep=0, when="1", probability=1.0)
+        agent = {"_id": "a0"}
+        assert evaluate_exposure_rule(rule, agent, 0) is True
+
+
+# ============================================================================
+# Channel Credibility
+# ============================================================================
+
+
+class TestGetChannelCredibility:
+    """Test get_channel_credibility(scenario, channel_name)."""
+
+    def test_existing_channel(self):
+        scenario = _make_scenario(
+            channels=[
+                ExposureChannel(
+                    name="email",
+                    description="Email",
+                    reach="targeted",
+                    credibility_modifier=0.8,
+                ),
+            ]
+        )
+        assert get_channel_credibility(scenario, "email") == 0.8
+
+    def test_missing_channel_returns_default(self):
+        scenario = _make_scenario()
+        assert get_channel_credibility(scenario, "nonexistent") == 1.0
+
+
+# ============================================================================
+# Seed Exposure Application
+# ============================================================================
+
+
+class TestApplySeedExposures:
+    """Test apply_seed_exposures(timestep, scenario, agents, state_manager, rng)."""
+
+    def test_all_agents_exposed_broadcast(self, tmp_path, ten_agents, rng):
+        """probability=1.0, when='true' → all 10 agents exposed."""
+        scenario = _make_scenario()
+        sm = StateManager(tmp_path / "test.db", agents=ten_agents)
+
+        count = apply_seed_exposures(0, scenario, ten_agents, sm, rng)
+
+        assert count == 10
+        for agent in ten_agents:
+            state = sm.get_agent_state(agent["_id"])
+            assert state.aware is True
+            assert state.exposure_count == 1
+
+    def test_no_exposure_wrong_timestep(self, tmp_path, ten_agents, rng):
+        """Rule at timestep=5, called at timestep=0 → no exposures."""
+        rules = [
+            ExposureRule(
+                channel="broadcast", timestep=5, when="true", probability=1.0
+            ),
+        ]
+        scenario = _make_scenario(rules=rules)
+        sm = StateManager(tmp_path / "test.db", agents=ten_agents)
+
+        count = apply_seed_exposures(0, scenario, ten_agents, sm, rng)
+        assert count == 0
+
+    def test_conditional_exposure(self, tmp_path, ten_agents, rng):
+        """Only agents matching condition get exposed."""
+        # ten_agents: roles cycle junior, mid, senior. Seniors at indices 2,5,8
+        rules = [
+            ExposureRule(
+                channel="broadcast",
+                timestep=0,
+                when="role == 'senior'",
+                probability=1.0,
+            ),
+        ]
+        scenario = _make_scenario(rules=rules)
+        sm = StateManager(tmp_path / "test.db", agents=ten_agents)
+
+        count = apply_seed_exposures(0, scenario, ten_agents, sm, rng)
+
+        # Seniors are at indices 2, 5, 8 (i % 3 == 2 in ten_agents fixture)
+        assert count == 3
+        for i in range(10):
+            state = sm.get_agent_state(f"a{i}")
+            if ten_agents[i]["role"] == "senior":
+                assert state.aware is True
+            else:
+                assert state.aware is False
+
+    def test_probabilistic_exposure(self, tmp_path, ten_agents):
+        """prob=0.5, seeded rng → deterministic subset."""
+        rules = [
+            ExposureRule(
+                channel="broadcast", timestep=0, when="true", probability=0.5
+            ),
+        ]
+        scenario = _make_scenario(rules=rules)
+        sm = StateManager(tmp_path / "test.db", agents=ten_agents)
+        rng = random.Random(42)
+
+        count = apply_seed_exposures(0, scenario, ten_agents, sm, rng)
+
+        # With seed 42 and prob=0.5, some but not all should be exposed
+        assert 0 < count < 10
+
+        # Deterministic: same seed, same result
+        sm2 = StateManager(tmp_path / "test2.db", agents=ten_agents)
+        rng2 = random.Random(42)
+        count2 = apply_seed_exposures(0, scenario, ten_agents, sm2, rng2)
+        assert count == count2
+
+    def test_credibility_calculation(self, tmp_path, rng):
+        """Exposure credibility = event_credibility * channel_credibility_modifier."""
+        agents = [{"_id": "a0", "age": 30}]
+        channels = [
+            ExposureChannel(
+                name="email",
+                description="Email",
+                reach="targeted",
+                credibility_modifier=0.8,
+            ),
+        ]
+        rules = [
+            ExposureRule(channel="email", timestep=0, when="true", probability=1.0),
+        ]
+        scenario = _make_scenario(
+            rules=rules, channels=channels, event_credibility=0.9
+        )
+        sm = StateManager(tmp_path / "test.db", agents=agents)
+
+        apply_seed_exposures(0, scenario, agents, sm, rng)
+
+        state = sm.get_agent_state("a0")
+        assert len(state.exposures) == 1
+        assert state.exposures[0].credibility == pytest.approx(0.72)  # 0.9 * 0.8
+
+    def test_already_aware_agent_gets_new_exposure(self, tmp_path, rng):
+        """An already-aware agent still receives additional exposures."""
+        agents = [{"_id": "a0", "age": 30}]
+        scenario = _make_scenario()
+        sm = StateManager(tmp_path / "test.db", agents=agents)
+
+        # First exposure
+        apply_seed_exposures(0, scenario, agents, sm, rng)
+        state = sm.get_agent_state("a0")
+        assert state.exposure_count == 1
+
+        # Add another rule at timestep=1
+        rules2 = [
+            ExposureRule(channel="broadcast", timestep=1, when="true", probability=1.0),
+        ]
+        scenario2 = _make_scenario(rules=rules2)
+        apply_seed_exposures(1, scenario2, agents, sm, rng)
+
+        state2 = sm.get_agent_state("a0")
+        assert state2.exposure_count == 2
+        assert state2.aware is True
+
+
+# ============================================================================
+# Network Neighbors
+# ============================================================================
+
+
+class TestGetNeighbors:
+    """Test get_neighbors(network, agent_id)."""
+
+    def test_hub_of_star(self, star_network):
+        neighbors = get_neighbors(star_network, "a0")
+        assert len(neighbors) == 9
+
+    def test_spoke_of_star(self, star_network):
+        neighbors = get_neighbors(star_network, "a1")
+        assert len(neighbors) == 1
+        assert neighbors[0][0] == "a0"
+
+    def test_chain_middle(self, linear_network):
+        neighbors = get_neighbors(linear_network, "a5")
+        assert len(neighbors) == 2
+        neighbor_ids = {n[0] for n in neighbors}
+        assert neighbor_ids == {"a4", "a6"}
+
+    def test_chain_endpoint(self, linear_network):
+        neighbors = get_neighbors(linear_network, "a0")
+        assert len(neighbors) == 1
+        assert neighbors[0][0] == "a1"
+
+    def test_isolated_agent(self):
+        """Agent with no edges has no neighbors."""
+        network = {
+            "meta": {"node_count": 3},
+            "nodes": [{"id": "a0"}, {"id": "a1"}, {"id": "a2"}],
+            "edges": [{"source": "a0", "target": "a1", "type": "colleague"}],
+        }
+        neighbors = get_neighbors(network, "a2")
+        assert len(neighbors) == 0
+
+    def test_bidirectional(self):
+        """Edge source→target means both can see each other."""
+        network = {
+            "meta": {"node_count": 2},
+            "nodes": [{"id": "a0"}, {"id": "a1"}],
+            "edges": [{"source": "a0", "target": "a1", "type": "colleague"}],
+        }
+        assert len(get_neighbors(network, "a0")) == 1
+        assert len(get_neighbors(network, "a1")) == 1
+
+
+# ============================================================================
+# Share Probability
+# ============================================================================
+
+
+class TestCalculateShareProbability:
+    """Test calculate_share_probability(agent, edge_data, spread_config, rng)."""
+
+    def test_base_probability_no_modifiers(self):
+        config = SpreadConfig(share_probability=0.3)
+        agent = {"_id": "a0", "age": 30}
+        edge = {"type": "colleague", "weight": 0.5}
+        rng = random.Random(42)
+
+        prob = calculate_share_probability(agent, edge, config, rng)
+        assert prob == 0.3
+
+    def test_modifier_multiply(self):
+        config = SpreadConfig(
+            share_probability=0.3,
+            share_modifiers=[SpreadModifier(when="True", multiply=2.0, add=0.0)],
+        )
+        agent = {"_id": "a0"}
+        edge = {"type": "colleague"}
+        rng = random.Random(42)
+
+        prob = calculate_share_probability(agent, edge, config, rng)
+        assert prob == pytest.approx(0.6)
+
+    def test_modifier_add(self):
+        config = SpreadConfig(
+            share_probability=0.3,
+            share_modifiers=[SpreadModifier(when="True", multiply=1.0, add=0.1)],
+        )
+        agent = {"_id": "a0"}
+        edge = {"type": "colleague"}
+        rng = random.Random(42)
+
+        prob = calculate_share_probability(agent, edge, config, rng)
+        assert prob == pytest.approx(0.4)
+
+    def test_clamp_upper(self):
+        """Modifier pushing probability above 1.0 gets clamped."""
+        config = SpreadConfig(
+            share_probability=0.8,
+            share_modifiers=[SpreadModifier(when="True", multiply=2.0, add=0.0)],
+        )
+        agent = {"_id": "a0"}
+        edge = {"type": "colleague"}
+        rng = random.Random(42)
+
+        prob = calculate_share_probability(agent, edge, config, rng)
+        assert prob == 1.0
+
+    def test_clamp_lower(self):
+        """Modifier pushing probability below 0 gets clamped."""
+        config = SpreadConfig(
+            share_probability=0.1,
+            share_modifiers=[SpreadModifier(when="True", multiply=1.0, add=-0.5)],
+        )
+        agent = {"_id": "a0"}
+        edge = {"type": "colleague"}
+        rng = random.Random(42)
+
+        prob = calculate_share_probability(agent, edge, config, rng)
+        assert prob == 0.0
+
+    def test_condition_not_met_skips_modifier(self):
+        config = SpreadConfig(
+            share_probability=0.3,
+            share_modifiers=[SpreadModifier(when="age > 100", multiply=5.0, add=0.0)],
+        )
+        agent = {"_id": "a0", "age": 30}
+        edge = {"type": "colleague"}
+        rng = random.Random(42)
+
+        prob = calculate_share_probability(agent, edge, config, rng)
+        assert prob == 0.3  # modifier skipped
+
+    def test_edge_type_in_context(self):
+        """Modifier can reference edge_type from edge_data."""
+        config = SpreadConfig(
+            share_probability=0.3,
+            share_modifiers=[
+                SpreadModifier(when="edge_type == 'mentor'", multiply=2.0, add=0.0)
+            ],
+        )
+        agent = {"_id": "a0", "age": 30}
+        edge_mentor = {"type": "mentor"}
+        edge_colleague = {"type": "colleague"}
+        rng = random.Random(42)
+
+        prob_mentor = calculate_share_probability(agent, edge_mentor, config, rng)
+        prob_colleague = calculate_share_probability(agent, edge_colleague, config, rng)
+
+        assert prob_mentor == pytest.approx(0.6)
+        assert prob_colleague == 0.3  # condition not met
+
+
+# ============================================================================
+# Network Propagation
+# ============================================================================
+
+
+class TestPropagateNetwork:
+    """Test propagate_through_network(...)."""
+
+    def _setup_sharer(self, sm, agent_id, timestep=0):
+        """Make an agent aware and willing to share."""
+        sm.record_exposure(
+            agent_id,
+            ExposureRecord(
+                timestep=timestep,
+                channel="broadcast",
+                content="test",
+                credibility=0.9,
+            ),
+        )
+        sm.update_agent_state(
+            agent_id,
+            AgentState(
+                agent_id=agent_id,
+                aware=True,
+                will_share=True,
+                position="adopt",
+                sentiment=0.5,
+                conviction=0.5,
+            ),
+            timestep=timestep,
+        )
+
+    def test_single_sharer_star(self, tmp_path, ten_agents, star_network):
+        """Hub shares to all spokes."""
+        scenario = _make_scenario(share_probability=1.0)
+        sm = StateManager(tmp_path / "test.db", agents=ten_agents)
+        rng = random.Random(42)
+
+        self._setup_sharer(sm, "a0")
+
+        count = propagate_through_network(
+            1, scenario, ten_agents, star_network, sm, rng
+        )
+
+        # Hub a0 has 9 neighbors, share_prob=1.0 → all 9 exposed
+        assert count == 9
+        for i in range(1, 10):
+            state = sm.get_agent_state(f"a{i}")
+            assert state.aware is True
+
+    def test_no_sharers_no_propagation(self, tmp_path, ten_agents, star_network):
+        """No agents with will_share=True → zero propagation."""
+        scenario = _make_scenario(share_probability=1.0)
+        sm = StateManager(tmp_path / "test.db", agents=ten_agents)
+        rng = random.Random(42)
+
+        count = propagate_through_network(
+            0, scenario, ten_agents, star_network, sm, rng
+        )
+        assert count == 0
+
+    def test_single_hop_in_chain(self, tmp_path, ten_agents, linear_network):
+        """In a chain, a0 sharing reaches a1 only (one hop per timestep call)."""
+        scenario = _make_scenario(share_probability=1.0)
+        sm = StateManager(tmp_path / "test.db", agents=ten_agents)
+        rng = random.Random(42)
+
+        self._setup_sharer(sm, "a0")
+
+        count = propagate_through_network(
+            1, scenario, ten_agents, linear_network, sm, rng
+        )
+
+        # a0 has one neighbor (a1) in the chain
+        assert count == 1
+        assert sm.get_agent_state("a1").aware is True
+        assert sm.get_agent_state("a2").aware is False
+
+    def test_peer_credibility_is_085(self, tmp_path, ten_agents, linear_network):
+        """Network exposures have credibility = 0.85."""
+        scenario = _make_scenario(share_probability=1.0)
+        sm = StateManager(tmp_path / "test.db", agents=ten_agents)
+        rng = random.Random(42)
+
+        self._setup_sharer(sm, "a0")
+        propagate_through_network(1, scenario, ten_agents, linear_network, sm, rng)
+
+        state = sm.get_agent_state("a1")
+        assert len(state.exposures) == 1
+        assert state.exposures[0].credibility == 0.85
+        assert state.exposures[0].channel == "network"
+        assert state.exposures[0].source_agent_id == "a0"
+
+    def test_already_aware_still_gets_exposure(self, tmp_path, ten_agents, linear_network):
+        """Already-aware agents still receive new exposures (multi-touch)."""
+        scenario = _make_scenario(share_probability=1.0)
+        sm = StateManager(tmp_path / "test.db", agents=ten_agents)
+        rng = random.Random(42)
+
+        # Make a1 already aware via seed
+        sm.record_exposure(
+            "a1",
+            ExposureRecord(
+                timestep=0, channel="broadcast", content="test", credibility=0.9
+            ),
+        )
+
+        self._setup_sharer(sm, "a0")
+        propagate_through_network(1, scenario, ten_agents, linear_network, sm, rng)
+
+        state = sm.get_agent_state("a1")
+        assert state.exposure_count == 2  # seed + network
+
+    def test_probabilistic_sharing(self, tmp_path, ten_agents, star_network):
+        """share_prob=0.5 with seeded rng → deterministic subset."""
+        scenario = _make_scenario(share_probability=0.5)
+        sm = StateManager(tmp_path / "test.db", agents=ten_agents)
+        rng = random.Random(42)
+
+        self._setup_sharer(sm, "a0")
+        count = propagate_through_network(
+            1, scenario, ten_agents, star_network, sm, rng
+        )
+
+        # With prob=0.5 and 9 neighbors, expect some but not all
+        assert 0 < count < 9

--- a/tests/test_reasoning_prompts.py
+++ b/tests/test_reasoning_prompts.py
@@ -1,0 +1,591 @@
+"""Tests for reasoning prompt construction and schema generation.
+
+Tests prompt building, schema generation, sentiment-to-tone mapping,
+and primary position outcome extraction. No LLM calls.
+Functions under test in entropy/simulation/reasoning.py.
+"""
+
+from datetime import datetime
+
+import pytest
+
+from entropy.core.models import (
+    ConvictionLevel,
+    ExposureRecord,
+    MemoryEntry,
+    PeerOpinion,
+    ReasoningContext,
+    float_to_conviction,
+)
+from entropy.core.models.scenario import (
+    Event,
+    EventType,
+    ExposureChannel,
+    ExposureRule,
+    InteractionConfig,
+    InteractionType,
+    OutcomeConfig,
+    OutcomeDefinition,
+    OutcomeType,
+    ScenarioMeta,
+    ScenarioSpec,
+    SeedExposure,
+    SimulationConfig,
+    SpreadConfig,
+    TimestepUnit,
+)
+from entropy.simulation.reasoning import (
+    _get_primary_position_outcome,
+    _sentiment_to_tone,
+    build_pass1_prompt,
+    build_pass1_schema,
+    build_pass2_prompt,
+    build_pass2_schema,
+)
+
+
+def _make_scenario(**overrides):
+    """Create a minimal scenario for prompt tests."""
+    defaults = dict(
+        meta=ScenarioMeta(
+            name="test",
+            description="Test",
+            population_spec="test.yaml",
+            agents_file="test.json",
+            network_file="test_network.json",
+            created_at=datetime(2024, 1, 1),
+        ),
+        event=Event(
+            type=EventType.PRODUCT_LAUNCH,
+            content="A revolutionary product is launching next month.",
+            source="TechCorp",
+            credibility=0.9,
+            ambiguity=0.2,
+            emotional_valence=0.3,
+        ),
+        seed_exposure=SeedExposure(
+            channels=[
+                ExposureChannel(
+                    name="broadcast",
+                    description="Broadcast",
+                    reach="broadcast",
+                    credibility_modifier=1.0,
+                )
+            ],
+            rules=[
+                ExposureRule(
+                    channel="broadcast", timestep=0, when="true", probability=1.0
+                )
+            ],
+        ),
+        interaction=InteractionConfig(
+            primary_model=InteractionType.PASSIVE_OBSERVATION,
+            description="Observe",
+        ),
+        spread=SpreadConfig(share_probability=0.3),
+        outcomes=OutcomeConfig(
+            suggested_outcomes=[
+                OutcomeDefinition(
+                    name="adoption",
+                    description="Product adoption decision",
+                    type=OutcomeType.CATEGORICAL,
+                    required=True,
+                    options=["adopt", "reject", "wait"],
+                ),
+            ],
+        ),
+        simulation=SimulationConfig(max_timesteps=5),
+    )
+    defaults.update(overrides)
+    return ScenarioSpec(**defaults)
+
+
+def _make_context(**overrides):
+    """Create a minimal ReasoningContext."""
+    defaults = dict(
+        agent_id="a0",
+        persona="You are a 35-year-old software engineer in San Francisco.",
+        event_content="A revolutionary product is launching.",
+        exposure_history=[
+            ExposureRecord(
+                timestep=0,
+                channel="broadcast",
+                content="A revolutionary product is launching.",
+                credibility=0.9,
+            ),
+        ],
+        peer_opinions=[],
+        current_state=None,
+        memory_trace=[],
+    )
+    defaults.update(overrides)
+    return ReasoningContext(**defaults)
+
+
+# ============================================================================
+# Pass 1 Prompt
+# ============================================================================
+
+
+class TestBuildPass1Prompt:
+    """Test build_pass1_prompt(context, scenario)."""
+
+    def test_persona_included(self):
+        context = _make_context(persona="You are a 50-year-old surgeon in Berlin.")
+        scenario = _make_scenario()
+        prompt = build_pass1_prompt(context, scenario)
+        assert "50-year-old surgeon in Berlin" in prompt
+
+    def test_event_content_included(self):
+        scenario = _make_scenario()
+        context = _make_context()
+        prompt = build_pass1_prompt(context, scenario)
+        assert "revolutionary product is launching" in prompt
+
+    def test_event_source_included(self):
+        scenario = _make_scenario()
+        context = _make_context()
+        prompt = build_pass1_prompt(context, scenario)
+        assert "TechCorp" in prompt
+
+    def test_seed_exposure_shows_channel(self):
+        """Non-network exposure shows channel name."""
+        context = _make_context(
+            exposure_history=[
+                ExposureRecord(
+                    timestep=0,
+                    channel="email",
+                    content="test",
+                    credibility=0.9,
+                    source_agent_id=None,
+                ),
+            ]
+        )
+        scenario = _make_scenario()
+        prompt = build_pass1_prompt(context, scenario)
+        assert "via email" in prompt
+
+    def test_network_exposure_shows_peer(self):
+        """Network exposure says 'someone in your network'."""
+        context = _make_context(
+            exposure_history=[
+                ExposureRecord(
+                    timestep=1,
+                    channel="network",
+                    content="test",
+                    credibility=0.85,
+                    source_agent_id="a5",
+                ),
+            ]
+        )
+        scenario = _make_scenario()
+        prompt = build_pass1_prompt(context, scenario)
+        assert "network" in prompt.lower()
+
+    def test_no_memory_section_on_first_reasoning(self):
+        """Empty memory_trace → no 'Previous Thinking' section."""
+        context = _make_context(memory_trace=[])
+        scenario = _make_scenario()
+        prompt = build_pass1_prompt(context, scenario)
+        assert "Previous Thinking" not in prompt
+
+    def test_memory_trace_included(self):
+        """Memory entries produce 'Your Previous Thinking' section."""
+        context = _make_context(
+            memory_trace=[
+                MemoryEntry(
+                    timestep=0,
+                    sentiment=0.3,
+                    conviction=0.5,
+                    summary="I think this could be useful.",
+                ),
+                MemoryEntry(
+                    timestep=2,
+                    sentiment=0.6,
+                    conviction=0.7,
+                    summary="After hearing more, I'm convinced.",
+                ),
+            ]
+        )
+        scenario = _make_scenario()
+        prompt = build_pass1_prompt(context, scenario)
+        assert "Previous Thinking" in prompt
+        assert "I think this could be useful" in prompt
+        assert "After hearing more" in prompt
+
+    def test_memory_trace_shows_conviction_label(self):
+        """Memory trace includes conviction label from float_to_conviction."""
+        context = _make_context(
+            memory_trace=[
+                MemoryEntry(
+                    timestep=0, sentiment=0.3, conviction=0.7, summary="Some thought"
+                ),
+            ]
+        )
+        scenario = _make_scenario()
+        prompt = build_pass1_prompt(context, scenario)
+        # conviction 0.7 → "firm"
+        assert "firm" in prompt
+
+    def test_peer_opinions_included(self):
+        """Peer opinions produce 'What People Around You Are Saying' section."""
+        context = _make_context(
+            peer_opinions=[
+                PeerOpinion(
+                    agent_id="a5",
+                    relationship="colleague",
+                    public_statement="This product will change everything.",
+                    sentiment=0.8,
+                ),
+            ]
+        )
+        scenario = _make_scenario()
+        prompt = build_pass1_prompt(context, scenario)
+        assert "People Around You Are Saying" in prompt
+        assert "This product will change everything" in prompt
+
+    def test_peer_sentiment_fallback(self):
+        """Peer without public_statement shows sentiment tone instead."""
+        context = _make_context(
+            peer_opinions=[
+                PeerOpinion(
+                    agent_id="a5",
+                    relationship="mentor",
+                    public_statement=None,
+                    sentiment=-0.7,
+                ),
+            ]
+        )
+        scenario = _make_scenario()
+        prompt = build_pass1_prompt(context, scenario)
+        assert "mentor" in prompt
+        # -0.7 → "strongly opposed"
+        assert "strongly opposed" in prompt
+
+    def test_peer_position_not_in_prompt(self):
+        """Peer's position label should NOT appear in the prompt (semantic influence only)."""
+        context = _make_context(
+            peer_opinions=[
+                PeerOpinion(
+                    agent_id="a5",
+                    relationship="colleague",
+                    position="reject",
+                    public_statement="I don't think this is worth it.",
+                    sentiment=-0.5,
+                ),
+            ]
+        )
+        scenario = _make_scenario()
+        prompt = build_pass1_prompt(context, scenario)
+
+        # The word "reject" as a position label shouldn't appear
+        # (it could appear in the public_statement if the person says it, but
+        # the prompt should not have a "position: reject" field)
+        assert "position" not in prompt.lower() or "position" in "passive_observation"
+
+    def test_re_reasoning_instructions_differ(self):
+        """With memory trace, prompt uses re-reasoning instructions."""
+        context_first = _make_context(memory_trace=[])
+        context_re = _make_context(
+            memory_trace=[
+                MemoryEntry(timestep=0, sentiment=0.3, conviction=0.5, summary="test"),
+            ]
+        )
+        scenario = _make_scenario()
+
+        prompt_first = build_pass1_prompt(context_first, scenario)
+        prompt_re = build_pass1_prompt(context_re, scenario)
+
+        # First reasoning asks about "gut reaction"
+        assert "gut reaction" in prompt_first.lower() or "genuine" in prompt_first.lower()
+        # Re-reasoning asks about evolution
+        assert "evolved" in prompt_re.lower() or "shifted" in prompt_re.lower()
+
+
+# ============================================================================
+# Pass 1 Schema
+# ============================================================================
+
+
+class TestBuildPass1Schema:
+    """Test build_pass1_schema()."""
+
+    def test_has_required_fields(self):
+        schema = build_pass1_schema()
+        required = schema["required"]
+        for field in [
+            "reasoning",
+            "public_statement",
+            "reasoning_summary",
+            "sentiment",
+            "conviction",
+            "will_share",
+        ]:
+            assert field in required
+
+    def test_sentiment_range(self):
+        schema = build_pass1_schema()
+        sentiment = schema["properties"]["sentiment"]
+        assert sentiment["minimum"] == -1.0
+        assert sentiment["maximum"] == 1.0
+
+    def test_conviction_is_enum(self):
+        """Conviction field uses ConvictionLevel enum values."""
+        schema = build_pass1_schema()
+        conviction = schema["properties"]["conviction"]
+        assert "enum" in conviction
+        for level in ConvictionLevel:
+            assert level.value in conviction["enum"]
+
+    def test_will_share_is_boolean(self):
+        schema = build_pass1_schema()
+        assert schema["properties"]["will_share"]["type"] == "boolean"
+
+    def test_no_additional_properties(self):
+        schema = build_pass1_schema()
+        assert schema["additionalProperties"] is False
+
+
+# ============================================================================
+# Pass 2 Prompt
+# ============================================================================
+
+
+class TestBuildPass2Prompt:
+    """Test build_pass2_prompt(reasoning_text, scenario)."""
+
+    def test_reasoning_text_included(self):
+        scenario = _make_scenario()
+        prompt = build_pass2_prompt("I really love this product.", scenario)
+        assert "I really love this product" in prompt
+
+    def test_classification_instruction(self):
+        scenario = _make_scenario()
+        prompt = build_pass2_prompt("Some reasoning text.", scenario)
+        assert "classif" in prompt.lower()
+
+    def test_extraction_instructions_included(self):
+        """If scenario has extraction_instructions, they appear in prompt."""
+        outcomes = OutcomeConfig(
+            suggested_outcomes=[
+                OutcomeDefinition(
+                    name="adoption",
+                    description="Decision",
+                    type=OutcomeType.CATEGORICAL,
+                    required=True,
+                    options=["adopt", "reject"],
+                ),
+            ],
+            extraction_instructions="Focus on explicit intent, not hedging.",
+        )
+        scenario = _make_scenario(outcomes=outcomes)
+        prompt = build_pass2_prompt("Some reasoning.", scenario)
+        assert "Focus on explicit intent" in prompt
+
+
+# ============================================================================
+# Pass 2 Schema
+# ============================================================================
+
+
+class TestBuildPass2Schema:
+    """Test build_pass2_schema(outcomes)."""
+
+    def test_categorical_outcome(self):
+        outcomes = OutcomeConfig(
+            suggested_outcomes=[
+                OutcomeDefinition(
+                    name="decision",
+                    description="User decision",
+                    type=OutcomeType.CATEGORICAL,
+                    required=True,
+                    options=["buy", "skip", "wait"],
+                ),
+            ]
+        )
+        schema = build_pass2_schema(outcomes)
+        assert schema is not None
+        assert "decision" in schema["properties"]
+        assert schema["properties"]["decision"]["enum"] == ["buy", "skip", "wait"]
+        assert "decision" in schema["required"]
+
+    def test_boolean_outcome(self):
+        outcomes = OutcomeConfig(
+            suggested_outcomes=[
+                OutcomeDefinition(
+                    name="will_try",
+                    description="Will try product",
+                    type=OutcomeType.BOOLEAN,
+                    required=True,
+                ),
+            ]
+        )
+        schema = build_pass2_schema(outcomes)
+        assert schema["properties"]["will_try"]["type"] == "boolean"
+
+    def test_float_outcome(self):
+        outcomes = OutcomeConfig(
+            suggested_outcomes=[
+                OutcomeDefinition(
+                    name="satisfaction",
+                    description="Satisfaction score",
+                    type=OutcomeType.FLOAT,
+                    required=False,
+                    range=[0.0, 10.0],
+                ),
+            ]
+        )
+        schema = build_pass2_schema(outcomes)
+        prop = schema["properties"]["satisfaction"]
+        assert prop["type"] == "number"
+        assert prop["minimum"] == 0.0
+        assert prop["maximum"] == 10.0
+        # Not required
+        assert "satisfaction" not in schema["required"]
+
+    def test_open_ended_outcome(self):
+        outcomes = OutcomeConfig(
+            suggested_outcomes=[
+                OutcomeDefinition(
+                    name="feedback",
+                    description="Free-text feedback",
+                    type=OutcomeType.OPEN_ENDED,
+                    required=False,
+                ),
+            ]
+        )
+        schema = build_pass2_schema(outcomes)
+        assert schema["properties"]["feedback"]["type"] == "string"
+
+    def test_multiple_outcomes(self):
+        outcomes = OutcomeConfig(
+            suggested_outcomes=[
+                OutcomeDefinition(
+                    name="decision",
+                    description="Decision",
+                    type=OutcomeType.CATEGORICAL,
+                    required=True,
+                    options=["a", "b"],
+                ),
+                OutcomeDefinition(
+                    name="confident",
+                    description="Confident",
+                    type=OutcomeType.BOOLEAN,
+                    required=True,
+                ),
+                OutcomeDefinition(
+                    name="score",
+                    description="Score",
+                    type=OutcomeType.FLOAT,
+                    required=False,
+                    range=[1.0, 5.0],
+                ),
+            ]
+        )
+        schema = build_pass2_schema(outcomes)
+        assert len(schema["properties"]) == 3
+        assert "decision" in schema["required"]
+        assert "confident" in schema["required"]
+        assert "score" not in schema["required"]
+
+    def test_no_outcomes_returns_none(self):
+        outcomes = OutcomeConfig(suggested_outcomes=[])
+        schema = build_pass2_schema(outcomes)
+        assert schema is None
+
+
+# ============================================================================
+# Helper Functions
+# ============================================================================
+
+
+class TestSentimentToTone:
+    """Test _sentiment_to_tone(sentiment)."""
+
+    @pytest.mark.parametrize(
+        "sentiment,expected",
+        [
+            (-0.9, "strongly opposed"),
+            (-0.7, "strongly opposed"),
+            (-0.4, "skeptical"),
+            (-0.1, "neutral"),
+            (0.0, "neutral"),
+            (0.1, "neutral"),
+            (0.3, "positive"),
+            (0.5, "positive"),
+            (0.7, "enthusiastic"),
+            (0.9, "enthusiastic"),
+        ],
+    )
+    def test_tone_mapping(self, sentiment, expected):
+        assert _sentiment_to_tone(sentiment) == expected
+
+    def test_boundary_negative(self):
+        """At exactly -0.6, should be 'skeptical'."""
+        assert _sentiment_to_tone(-0.6) == "skeptical"
+
+    def test_boundary_positive(self):
+        """At exactly 0.6, should be 'enthusiastic'."""
+        assert _sentiment_to_tone(0.6) == "enthusiastic"
+
+
+class TestGetPrimaryPositionOutcome:
+    """Test _get_primary_position_outcome(scenario)."""
+
+    def test_required_categorical_found(self):
+        scenario = _make_scenario()
+        assert _get_primary_position_outcome(scenario) == "adoption"
+
+    def test_no_categorical_returns_none(self):
+        """Scenario with only boolean outcomes → None."""
+        outcomes = OutcomeConfig(
+            suggested_outcomes=[
+                OutcomeDefinition(
+                    name="interested",
+                    description="Interested",
+                    type=OutcomeType.BOOLEAN,
+                    required=True,
+                ),
+            ]
+        )
+        scenario = _make_scenario(outcomes=outcomes)
+        assert _get_primary_position_outcome(scenario) is None
+
+    def test_unrequired_categorical_used_as_fallback(self):
+        """If no required categorical, first categorical is used."""
+        outcomes = OutcomeConfig(
+            suggested_outcomes=[
+                OutcomeDefinition(
+                    name="preference",
+                    description="Preference",
+                    type=OutcomeType.CATEGORICAL,
+                    required=False,
+                    options=["a", "b"],
+                ),
+            ]
+        )
+        scenario = _make_scenario(outcomes=outcomes)
+        assert _get_primary_position_outcome(scenario) == "preference"
+
+    def test_first_required_categorical_preferred(self):
+        """Multiple categoricals — first required one is chosen."""
+        outcomes = OutcomeConfig(
+            suggested_outcomes=[
+                OutcomeDefinition(
+                    name="secondary",
+                    description="Secondary",
+                    type=OutcomeType.CATEGORICAL,
+                    required=False,
+                    options=["x", "y"],
+                ),
+                OutcomeDefinition(
+                    name="primary",
+                    description="Primary",
+                    type=OutcomeType.CATEGORICAL,
+                    required=True,
+                    options=["a", "b"],
+                ),
+            ]
+        )
+        scenario = _make_scenario(outcomes=outcomes)
+        assert _get_primary_position_outcome(scenario) == "primary"

--- a/tests/test_stopping.py
+++ b/tests/test_stopping.py
@@ -1,0 +1,277 @@
+"""Tests for stopping condition evaluation.
+
+Tests condition parsing, comparison evaluation, convergence detection,
+and the top-level stopping condition evaluator.
+Functions under test in entropy/simulation/stopping.py.
+"""
+
+import pytest
+
+from entropy.core.models import TimestepSummary
+from entropy.core.models.scenario import SimulationConfig, TimestepUnit
+from entropy.simulation.state import StateManager
+from entropy.simulation.stopping import (
+    evaluate_convergence,
+    evaluate_no_state_changes,
+    evaluate_stopping_conditions,
+    parse_comparison,
+)
+
+
+def _make_summary(timestep=0, **kwargs):
+    """Factory for TimestepSummary with sensible defaults."""
+    defaults = {
+        "timestep": timestep,
+        "new_exposures": 0,
+        "agents_reasoned": 0,
+        "shares_occurred": 0,
+        "state_changes": 0,
+        "exposure_rate": 0.0,
+        "position_distribution": {},
+        "average_sentiment": None,
+        "average_conviction": None,
+        "sentiment_variance": None,
+    }
+    defaults.update(kwargs)
+    return TimestepSummary(**defaults)
+
+
+class TestParseComparison:
+    """Test condition string parsing."""
+
+    def test_greater_than(self):
+        assert parse_comparison("exposure_rate > 0.95") == ("exposure_rate", ">", 0.95)
+
+    def test_less_than(self):
+        assert parse_comparison("average_sentiment < 0.0") == (
+            "average_sentiment",
+            "<",
+            0.0,
+        )
+
+    def test_greater_equal(self):
+        assert parse_comparison("exposure_rate >= 1.0") == (
+            "exposure_rate",
+            ">=",
+            1.0,
+        )
+
+    def test_less_equal(self):
+        assert parse_comparison("exposure_rate <= 0.5") == (
+            "exposure_rate",
+            "<=",
+            0.5,
+        )
+
+    def test_equal(self):
+        assert parse_comparison("state_changes == 0") == ("state_changes", "==", 0.0)
+
+    def test_not_equal(self):
+        assert parse_comparison("exposure_rate != 0.0") == (
+            "exposure_rate",
+            "!=",
+            0.0,
+        )
+
+    def test_invalid_format_returns_none(self):
+        assert parse_comparison("not a condition") is None
+
+    def test_whitespace_handling(self):
+        assert parse_comparison("  exposure_rate  >  0.95  ") == (
+            "exposure_rate",
+            ">",
+            0.95,
+        )
+
+    def test_integer_value(self):
+        assert parse_comparison("state_changes > 5") == ("state_changes", ">", 5.0)
+
+
+class TestEvaluateNoStateChanges:
+    """Test no_state_changes_for condition evaluation."""
+
+    def test_stable_exceeds_threshold(self):
+        """11 stable timesteps satisfies > 10."""
+        summaries = [_make_summary(i, state_changes=0) for i in range(11)]
+        assert evaluate_no_state_changes("no_state_changes_for > 10", summaries) is True
+
+    def test_exactly_at_threshold(self):
+        """10 stable timesteps satisfies > 10 because we check the last N."""
+        summaries = [_make_summary(i, state_changes=0) for i in range(10)]
+        assert (
+            evaluate_no_state_changes("no_state_changes_for > 10", summaries) is True
+        )
+
+    def test_not_enough_summaries(self):
+        """5 summaries can't satisfy > 10."""
+        summaries = [_make_summary(i, state_changes=0) for i in range(5)]
+        assert (
+            evaluate_no_state_changes("no_state_changes_for > 10", summaries) is False
+        )
+
+    def test_recent_change_breaks_stability(self):
+        """A state change in the last N timesteps fails the check."""
+        summaries = [_make_summary(i, state_changes=0) for i in range(15)]
+        summaries[-1] = _make_summary(14, state_changes=1)
+        assert (
+            evaluate_no_state_changes("no_state_changes_for > 10", summaries) is False
+        )
+
+    def test_empty_summaries(self):
+        assert evaluate_no_state_changes("no_state_changes_for > 5", []) is False
+
+    def test_invalid_format(self):
+        summaries = [_make_summary(i) for i in range(10)]
+        assert evaluate_no_state_changes("bad_format", summaries) is False
+
+
+class TestEvaluateConvergence:
+    """Test position distribution convergence detection."""
+
+    def test_stable_distribution_converged(self):
+        """Identical distributions over window → converged."""
+        dist = {"adopt": 70, "reject": 30}
+        summaries = [_make_summary(i, position_distribution=dist) for i in range(5)]
+        assert evaluate_convergence(summaries, window=5, tolerance=0.01) is True
+
+    def test_shifting_distribution_not_converged(self):
+        """Varying distributions → not converged."""
+        summaries = [
+            _make_summary(0, position_distribution={"adopt": 40, "reject": 60}),
+            _make_summary(1, position_distribution={"adopt": 50, "reject": 50}),
+            _make_summary(2, position_distribution={"adopt": 60, "reject": 40}),
+            _make_summary(3, position_distribution={"adopt": 70, "reject": 30}),
+            _make_summary(4, position_distribution={"adopt": 80, "reject": 20}),
+        ]
+        assert evaluate_convergence(summaries, window=5, tolerance=0.01) is False
+
+    def test_insufficient_window(self):
+        """Fewer summaries than window → not converged."""
+        dist = {"adopt": 70, "reject": 30}
+        summaries = [_make_summary(i, position_distribution=dist) for i in range(3)]
+        assert evaluate_convergence(summaries, window=5, tolerance=0.01) is False
+
+    def test_high_tolerance_accepts_drift(self):
+        """Moderate drift within high tolerance → converged."""
+        summaries = [
+            _make_summary(0, position_distribution={"adopt": 68, "reject": 32}),
+            _make_summary(1, position_distribution={"adopt": 70, "reject": 30}),
+            _make_summary(2, position_distribution={"adopt": 72, "reject": 28}),
+            _make_summary(3, position_distribution={"adopt": 70, "reject": 30}),
+            _make_summary(4, position_distribution={"adopt": 71, "reject": 29}),
+        ]
+        assert evaluate_convergence(summaries, window=5, tolerance=0.1) is True
+
+    def test_empty_distributions(self):
+        """All empty position distributions → not converged (no positions to check)."""
+        summaries = [_make_summary(i, position_distribution={}) for i in range(5)]
+        assert evaluate_convergence(summaries, window=5) is False
+
+
+class TestEvaluateStoppingConditions:
+    """Test the top-level stopping condition evaluator."""
+
+    def _make_state_manager(self, tmp_path, agents, aware_ids=None):
+        """Create a StateManager with some agents optionally made aware."""
+        from entropy.core.models import ExposureRecord
+
+        sm = StateManager(tmp_path / "test.db", agents=agents)
+        for aid in aware_ids or []:
+            sm.record_exposure(
+                aid,
+                ExposureRecord(
+                    timestep=0,
+                    channel="broadcast",
+                    content="test",
+                    credibility=0.9,
+                ),
+            )
+        return sm
+
+    def test_max_timesteps_reached(self, tmp_path):
+        """Stops when timestep >= max_timesteps - 1."""
+        agents = [{"_id": "a0"}]
+        sm = self._make_state_manager(tmp_path, agents)
+        config = SimulationConfig(max_timesteps=100)
+
+        should_stop, reason = evaluate_stopping_conditions(99, config, sm, [])
+        assert should_stop is True
+        assert reason == "max_timesteps_reached"
+
+    def test_before_max_timesteps(self, tmp_path):
+        """Doesn't stop before max_timesteps with no conditions."""
+        agents = [{"_id": "a0"}]
+        sm = self._make_state_manager(tmp_path, agents)
+        config = SimulationConfig(max_timesteps=100)
+
+        should_stop, reason = evaluate_stopping_conditions(50, config, sm, [])
+        assert should_stop is False
+        assert reason is None
+
+    def test_exposure_rate_condition_met(self, tmp_path):
+        """Stops when exposure rate exceeds threshold."""
+        agents = [{"_id": f"a{i}"} for i in range(10)]
+        # Make 10/10 agents aware → 100% exposure rate
+        sm = self._make_state_manager(
+            tmp_path, agents, aware_ids=[f"a{i}" for i in range(10)]
+        )
+        config = SimulationConfig(
+            max_timesteps=100,
+            stop_conditions=["exposure_rate > 0.95"],
+        )
+
+        should_stop, reason = evaluate_stopping_conditions(10, config, sm, [])
+        assert should_stop is True
+        assert "exposure_rate" in reason
+
+    def test_exposure_rate_condition_not_met(self, tmp_path):
+        """Doesn't stop when exposure rate is below threshold."""
+        agents = [{"_id": f"a{i}"} for i in range(10)]
+        # Make 3/10 agents aware → 30% exposure rate
+        sm = self._make_state_manager(
+            tmp_path, agents, aware_ids=["a0", "a1", "a2"]
+        )
+        config = SimulationConfig(
+            max_timesteps=100,
+            stop_conditions=["exposure_rate > 0.95"],
+        )
+
+        should_stop, reason = evaluate_stopping_conditions(10, config, sm, [])
+        assert should_stop is False
+        assert reason is None
+
+    def test_no_stop_conditions(self, tmp_path):
+        """No custom conditions and not at max → doesn't stop."""
+        agents = [{"_id": "a0"}]
+        sm = self._make_state_manager(tmp_path, agents)
+        config = SimulationConfig(max_timesteps=100, stop_conditions=None)
+
+        should_stop, reason = evaluate_stopping_conditions(50, config, sm, [])
+        assert should_stop is False
+
+    def test_convergence_condition(self, tmp_path):
+        """Convergence condition triggers when distribution is stable."""
+        agents = [{"_id": "a0"}]
+        sm = self._make_state_manager(tmp_path, agents)
+        config = SimulationConfig(
+            max_timesteps=100,
+            stop_conditions=["convergence"],
+        )
+        dist = {"adopt": 70, "reject": 30}
+        summaries = [_make_summary(i, position_distribution=dist) for i in range(10)]
+
+        should_stop, reason = evaluate_stopping_conditions(10, config, sm, summaries)
+        assert should_stop is True
+
+    def test_no_state_changes_condition(self, tmp_path):
+        """No state changes condition triggers after enough stable timesteps."""
+        agents = [{"_id": "a0"}]
+        sm = self._make_state_manager(tmp_path, agents)
+        config = SimulationConfig(
+            max_timesteps=100,
+            stop_conditions=["no_state_changes_for > 5"],
+        )
+        summaries = [_make_summary(i, state_changes=0) for i in range(10)]
+
+        should_stop, reason = evaluate_stopping_conditions(10, config, sm, summaries)
+        assert should_stop is True


### PR DESCRIPTION
## Summary
- Adds 158 unit tests across 6 new test files covering simulation validation logic
- Tests cover conviction system, memory traces, propagation, reasoning prompts, stopping conditions, and integration timestep behavior
- Extends `conftest.py` with additional shared fixtures

## Files
- `tests/test_conviction.py` — conviction level mapping and flip resistance
- `tests/test_integration_timestep.py` — full timestep integration scenarios
- `tests/test_memory_traces.py` — sliding window memory trace behavior
- `tests/test_propagation.py` — network exposure propagation logic
- `tests/test_reasoning_prompts.py` — two-pass reasoning prompt construction
- `tests/test_stopping.py` — compound stopping condition evaluation

## Test plan
- [ ] `pytest tests/` passes with no failures
- [ ] No conflicts with network refactor changes on `code-cleanup`

🤖 Generated with [Claude Code](https://claude.com/claude-code)