### PR TITLE
Track per-run token usage and cost in meta.json

### DIFF
--- a/entropy/core/llm.py
+++ b/entropy/core/llm.py
@@ -13,7 +13,7 @@ When validation fails, pass the error message back to let the LLM self-correct.
 """
 
 from .providers import get_pipeline_provider, get_simulation_provider
-from .providers.base import ValidatorCallback, RetryCallback
+from .providers.base import TokenUsage, ValidatorCallback, RetryCallback
 from ..config import get_config
 
 
@@ -22,6 +22,7 @@ __all__ = [
     "simple_call_async",
     "reasoning_call",
     "agentic_research",
+    "TokenUsage",
     "ValidatorCallback",
     "RetryCallback",
 ]
@@ -83,12 +84,13 @@ async def simple_call_async(
     schema_name: str = "response",
     model: str | None = None,
     max_tokens: int | None = None,
-) -> dict:
+) -> tuple[dict, TokenUsage]:
     """Async version of simple_call for concurrent API requests.
 
     Routed through the SIMULATION provider.
 
     Used for batch agent reasoning during simulation.
+    Returns (structured_data, token_usage) tuple.
     """
     provider = get_simulation_provider()
     effective_model = model or _get_simulation_model_override()

--- a/entropy/core/models/simulation.py
+++ b/entropy/core/models/simulation.py
@@ -300,6 +300,12 @@ class ReasoningResponse(BaseModel):
         default_factory=dict, description="All structured outcomes (from Pass 2)"
     )
 
+    # Token usage tracking (populated by two-pass reasoning)
+    pass1_input_tokens: int = Field(default=0, description="Pass 1 input tokens")
+    pass1_output_tokens: int = Field(default=0, description="Pass 1 output tokens")
+    pass2_input_tokens: int = Field(default=0, description="Pass 2 input tokens")
+    pass2_output_tokens: int = Field(default=0, description="Pass 2 output tokens")
+
 
 # =============================================================================
 # Simulation Configuration

--- a/entropy/core/providers/base.py
+++ b/entropy/core/providers/base.py
@@ -1,10 +1,19 @@
 """Abstract base class for LLM providers."""
 
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from typing import Callable, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from ..rate_limiter import RateLimiter
+
+
+@dataclass
+class TokenUsage:
+    """Token usage from a single LLM API call."""
+
+    input_tokens: int = 0
+    output_tokens: int = 0
 
 
 # Type for validation callbacks: takes response data, returns (is_valid, error_message)
@@ -129,7 +138,7 @@ class LLMProvider(ABC):
         schema_name: str = "response",
         model: str | None = None,
         max_tokens: int | None = None,
-    ) -> dict:
+    ) -> tuple[dict, TokenUsage]:
         """Async version of simple_call for concurrent API requests."""
         ...
 

--- a/tests/test_integration_timestep.py
+++ b/tests/test_integration_timestep.py
@@ -18,6 +18,7 @@ from entropy.core.models import (
     ReasoningResponse,
     SimulationRunConfig,
 )
+from entropy.simulation.reasoning import BatchTokenUsage
 from entropy.core.models.scenario import (
     Event,
     EventType,
@@ -205,7 +206,7 @@ def _mock_batch_reason(responses_map=None, default_response=None):
                 results.append((ctx.agent_id, responses_map[ctx.agent_id]))
             else:
                 results.append((ctx.agent_id, default_response))
-        return results
+        return results, BatchTokenUsage()
 
     return mock_fn
 


### PR DESCRIPTION
## Summary
- Thread actual token counts from API responses through provider → facade → reasoning → engine → `meta.json`
- Each provider's `simple_call_async` now returns `(dict, TokenUsage)` with real token counts from the API response
- Two-pass reasoning captures tokens from both pivotal (Pass 1) and routine (Pass 2) calls, engine accumulates across chunks and computes estimated USD cost via `pricing.py`

## Changes
- **`providers/base.py`** — `TokenUsage` dataclass, updated abstract signature
- **`providers/openai.py`** — Extract usage from Responses API (`input_tokens`/`output_tokens`) and Chat Completions API (`prompt_tokens`/`completion_tokens`)
- **`providers/claude.py`** — Extract usage from `response.usage`
- **`llm.py`** — Pass-through tuple return from `simple_call_async`
- **`models/simulation.py`** — Token fields on `ReasoningResponse`
- **`reasoning.py`** — `BatchTokenUsage` dataclass, capture tokens in two-pass flow, accumulate in `batch_reason_agents`
- **`engine.py`** — Running totals, `_compute_cost()` using `pricing.py`, write `cost` block to `meta.json`

## meta.json output
```json
"cost": {
  "pivotal_input_tokens": 1234567,
  "pivotal_output_tokens": 456789,
  "routine_input_tokens": 234567,
  "routine_output_tokens": 89012,
  "total_input_tokens": 1469134,
  "total_output_tokens": 545801,
  "pivotal_model": "gpt-5",
  "routine_model": "gpt-5-mini",
  "estimated_usd": 5.1234
}
```

## Test plan
- [x] All 618 existing tests pass with updated return types
- [x] 6 new provider token extraction tests (OpenAI Responses, Chat Completions, Claude, null usage)
- [x] 3 new engine tests (chunk accumulation, meta.json cost output, unknown model handling)
- [x] `ruff check` and `ruff format` clean
- [ ] Manual: run a small simulation, verify `meta.json` contains correct `cost` block

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)