### PR TITLE
Fix #85: preserve dependent names when promoting to full agents

### DIFF
--- a/extropy/population/sampler/core.py
+++ b/extropy/population/sampler/core.py
@@ -310,6 +310,11 @@ def _sample_dependent_as_agent(
     agent["household_id"] = household_id
     agent["household_role"] = f"dependent_{dependent.relationship}"
     agent["relationship_to_primary"] = dependent.relationship
+    dep_name = str(getattr(dependent, "name", "")).strip()
+    if dep_name:
+        agent["first_name"] = dep_name
+    if parent.get("last_name"):
+        agent["last_name"] = parent["last_name"]
 
     # Copy household-scoped attributes from parent
     for attr in spec.attributes:


### PR DESCRIPTION
## Summary
- ensure promoted dependents carry first_name from dependent household metadata
- preserve household last name when available for promoted dependents
- add regression test verifying promoted dependent names align with generated household dependent records

## Validation
- pytest -q tests/test_agent_focus.py::TestPromotedDependentNames::test_promoted_dependents_preserve_household_names

Closes #85