### PR TITLE
Fix #88: inject timestep macro summaries into next-turn prompts

### DIFF
--- a/extropy/simulation/reasoning.py
+++ b/extropy/simulation/reasoning.py
@@ -174,7 +174,7 @@ def build_pass1_prompt(
 
     # --- Macro summary ---
     if context.macro_summary:
-        prompt_parts.extend(["", context.macro_summary])
+        prompt_parts.extend(["", "## The Broader Climate", "", context.macro_summary])
 
     # --- Timeline recap (Phase C) ---
     if context.timeline_recap:

--- a/tests/test_reasoning_prompts.py
+++ b/tests/test_reasoning_prompts.py
@@ -381,6 +381,7 @@ class TestPhaseAPromptFeatures:
         context = _make_context(macro_summary="Most people are still undecided.")
         scenario = _make_scenario()
         prompt = build_pass1_prompt(context, scenario)
+        assert "The Broader Climate" in prompt
         assert "Most people are still undecided" in prompt
 
     def test_local_mood_included(self):


### PR DESCRIPTION
## Summary
- pass previous timestep summary into macro rendering so trend/momentum can be computed
- strengthen macro summary text for leader/minority framing, sentiment trend, exposure saturation, and action momentum
- render macro context under an explicit `The Broader Climate` heading in pass-1 prompts
- add targeted tests for macro rendering outputs and prompt inclusion

## Testing
- pytest -q tests/test_engine.py::TestTokenAccumulation::test_macro_summary_renders_trend_and_saturation tests/test_engine.py::TestTokenAccumulation::test_macro_summary_renders_waiting_momentum tests/test_reasoning_prompts.py::TestPhaseAPromptFeatures::test_macro_summary_included
- ruff check extropy/simulation/engine.py extropy/simulation/reasoning.py tests/test_engine.py tests/test_reasoning_prompts.py

Closes #88
