### PR TITLE
Fix #89: make THINK vs SAY divergence observable

### DIFF
--- a/extropy/core/models/simulation.py
+++ b/extropy/core/models/simulation.py
@@ -357,6 +357,10 @@ class ReasoningResponse(BaseModel):
     position: str | None = Field(
         default=None, description="Classified position (filled by Pass 2)"
     )
+    public_position: str | None = Field(
+        default=None,
+        description="Public-facing position when THINK/SAY diverges (high fidelity)",
+    )
     sentiment: float | None = Field(
         default=None, description="Sentiment value (-1 to 1)"
     )

--- a/extropy/simulation/engine.py
+++ b/extropy/simulation/engine.py
@@ -926,7 +926,8 @@ class SimulationEngine:
                 public_conviction = max(0.0, min(1.0, public_conviction))
 
             public_will_share = response.will_share
-            public_position = response.position
+            candidate_public_position = response.public_position or response.position
+            public_position = candidate_public_position
 
             if (
                 old_public_conviction is not None
@@ -934,8 +935,8 @@ class SimulationEngine:
             ):
                 if (
                     old_public_position is not None
-                    and response.position is not None
-                    and old_public_position != response.position
+                    and candidate_public_position is not None
+                    and old_public_position != candidate_public_position
                 ):
                     new_conviction = (
                         public_conviction if public_conviction is not None else 0.0
@@ -943,7 +944,7 @@ class SimulationEngine:
                     if new_conviction < _MODERATE_CONVICTION:
                         logger.info(
                             f"[CONVICTION] Agent {agent_id}: public flip from {old_public_position} "
-                            f"to {response.position} rejected (old conviction={float_to_conviction(old_public_conviction)}, "
+                            f"to {candidate_public_position} rejected (old conviction={float_to_conviction(old_public_conviction)}, "
                             f"new conviction={float_to_conviction(public_conviction)})"
                         )
                         public_position = old_public_position
@@ -2041,6 +2042,7 @@ class SimulationEngine:
             "population_size": len(self.agents),
             "strong_model": self.config.strong,
             "fast_model": self.config.fast,
+            "fidelity": self.config.fidelity,
             "seed": self.seed,
             "multi_touch_threshold": self.config.multi_touch_threshold,
             "completed_at": datetime.now().isoformat(),

--- a/tests/test_reasoning_execution.py
+++ b/tests/test_reasoning_execution.py
@@ -1,0 +1,197 @@
+"""Execution-path tests for two-pass reasoning."""
+
+import asyncio
+from datetime import datetime
+from unittest.mock import AsyncMock, patch
+
+from extropy.core.llm import TokenUsage
+from extropy.core.models import ExposureRecord, ReasoningContext, SimulationRunConfig
+from extropy.core.models.scenario import (
+    Event,
+    EventType,
+    ExposureChannel,
+    ExposureRule,
+    InteractionConfig,
+    InteractionType,
+    OutcomeConfig,
+    OutcomeDefinition,
+    OutcomeType,
+    ScenarioMeta,
+    ScenarioSpec,
+    SeedExposure,
+    SimulationConfig,
+    SpreadConfig,
+)
+from extropy.simulation.reasoning import _reason_agent_two_pass_async
+
+
+def _make_scenario() -> ScenarioSpec:
+    return ScenarioSpec(
+        meta=ScenarioMeta(
+            name="test",
+            description="Test scenario",
+            population_spec="population.v1.yaml",
+            study_db="study.db",
+            population_id="default",
+            network_id="default",
+            created_at=datetime(2024, 1, 1),
+        ),
+        event=Event(
+            type=EventType.PRODUCT_LAUNCH,
+            content="A new policy is announced.",
+            source="City Hall",
+            credibility=0.9,
+            ambiguity=0.3,
+            emotional_valence=-0.1,
+        ),
+        seed_exposure=SeedExposure(
+            channels=[
+                ExposureChannel(
+                    name="broadcast",
+                    description="Broadcast",
+                    reach="broadcast",
+                    credibility_modifier=1.0,
+                )
+            ],
+            rules=[
+                ExposureRule(
+                    channel="broadcast",
+                    timestep=0,
+                    when="true",
+                    probability=1.0,
+                )
+            ],
+        ),
+        interaction=InteractionConfig(
+            primary_model=InteractionType.PASSIVE_OBSERVATION,
+            description="Observe",
+        ),
+        spread=SpreadConfig(share_probability=0.3),
+        outcomes=OutcomeConfig(
+            suggested_outcomes=[
+                OutcomeDefinition(
+                    name="adoption",
+                    description="Primary stance",
+                    type=OutcomeType.CATEGORICAL,
+                    required=True,
+                    options=["adopt", "reject", "wait"],
+                )
+            ]
+        ),
+        simulation=SimulationConfig(max_timesteps=3),
+    )
+
+
+def _make_context() -> ReasoningContext:
+    return ReasoningContext(
+        agent_id="a0",
+        persona="I'm Alex, a resident in the city.",
+        event_content="A new policy is announced.",
+        exposure_history=[
+            ExposureRecord(
+                timestep=0,
+                channel="broadcast",
+                content="A new policy is announced.",
+                credibility=0.9,
+            )
+        ],
+        peer_opinions=[],
+        agent_name="Alex",
+        timestep=0,
+        timestep_unit="day",
+    )
+
+
+def test_two_pass_high_fidelity_classifies_private_and_public_positions_separately():
+    scenario = _make_scenario()
+    context = _make_context()
+    config = SimulationRunConfig(
+        scenario_path="test.yaml",
+        output_dir="results",
+        max_retries=1,
+        fidelity="high",
+    )
+
+    pass1_response = {
+        "reasoning": "I can see both sides, but I'm conflicted.",
+        "private_thought": "I privately reject this policy.",
+        "public_statement": "Let's stay open-minded and give it a chance.",
+        "reasoning_summary": "I'm conflicted.",
+        "sentiment": -0.2,
+        "conviction": 62,
+        "will_share": True,
+        "actions": [],
+    }
+
+    mocked_call = AsyncMock(
+        side_effect=[
+            (pass1_response, TokenUsage(input_tokens=10, output_tokens=7)),
+            ({"adoption": "reject"}, TokenUsage(input_tokens=4, output_tokens=2)),
+            ({"adoption": "adopt"}, TokenUsage(input_tokens=5, output_tokens=3)),
+        ]
+    )
+
+    with patch("extropy.simulation.reasoning.simple_call_async", mocked_call):
+        response = asyncio.run(
+            _reason_agent_two_pass_async(
+                context=context,
+                scenario=scenario,
+                config=config,
+                rate_limiter=None,
+            )
+        )
+
+    assert response is not None
+    assert response.position == "reject"
+    assert response.public_position == "adopt"
+    assert response.pass2_input_tokens == 9
+    assert response.pass2_output_tokens == 5
+    assert mocked_call.await_count == 3
+    assert "I privately reject this policy" in mocked_call.await_args_list[1].kwargs[
+        "prompt"
+    ]
+    assert "give it a chance" in mocked_call.await_args_list[2].kwargs["prompt"]
+
+
+def test_two_pass_medium_fidelity_uses_private_classification_for_public_position():
+    scenario = _make_scenario()
+    context = _make_context()
+    config = SimulationRunConfig(
+        scenario_path="test.yaml",
+        output_dir="results",
+        max_retries=1,
+        fidelity="medium",
+    )
+
+    pass1_response = {
+        "reasoning": "I am leaning toward waiting.",
+        "private_thought": "I should wait and watch.",
+        "public_statement": "I'm not sure yet.",
+        "reasoning_summary": "Leaning to wait.",
+        "sentiment": 0.0,
+        "conviction": 45,
+        "will_share": False,
+        "actions": [],
+    }
+
+    mocked_call = AsyncMock(
+        side_effect=[
+            (pass1_response, TokenUsage(input_tokens=8, output_tokens=6)),
+            ({"adoption": "wait"}, TokenUsage(input_tokens=3, output_tokens=2)),
+        ]
+    )
+
+    with patch("extropy.simulation.reasoning.simple_call_async", mocked_call):
+        response = asyncio.run(
+            _reason_agent_two_pass_async(
+                context=context,
+                scenario=scenario,
+                config=config,
+                rate_limiter=None,
+            )
+        )
+
+    assert response is not None
+    assert response.position == "wait"
+    assert response.public_position == "wait"
+    assert mocked_call.await_count == 2


### PR DESCRIPTION
## Summary
- add `public_position` to `ReasoningResponse` so high-fidelity reasoning can carry a separate public stance
- classify private position from `private_thought` (fallback to reasoning), and classify public position from `public_statement` at high fidelity
- apply `response.public_position` in engine state updates (fallback to `response.position`) so divergence persists to DB-visible state
- include `fidelity` in `meta.json` for run auditability
- add tests for async two-pass divergence classification, engine public-position override behavior, and fidelity metadata export

## Testing
- pytest -q tests/test_reasoning_execution.py tests/test_engine.py::TestFlipResistance::test_public_position_prefers_explicit_public_field tests/test_engine.py::TestTokenAccumulation::test_cost_in_meta_json
- ruff check extropy/core/models/simulation.py extropy/simulation/engine.py extropy/simulation/reasoning.py tests/test_engine.py tests/test_reasoning_execution.py

Closes #89
