### PR TITLE
fix: correct CLI help text and docs discrepancies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,7 +110,6 @@ Non-interactive chat for automation:
 
 ```bash
 extropy chat ask \
-  --study-db study.db \
   --agent-id agent_042 \
   --prompt "What changed your mind?" \
   --json
@@ -119,7 +118,7 @@ extropy chat ask \
 List available agents:
 
 ```bash
-extropy chat list --study-db study.db --json
+extropy chat list --json
 ```
 
 **Note:** The interactive REPL (`extropy chat`) requires a TTY and is not suitable for automation. Use `extropy chat ask` instead.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -239,7 +239,7 @@ Run a simulation from a scenario spec.
 
 ```bash
 extropy simulate -s ai-adoption
-extropy simulate -s ai-adoption --seed 42 --strong openai/gpt-5
+extropy simulate -s ai-adoption --seed 42 --strong anthropic/claude-sonnet-4-6
 extropy simulate -s ai-adoption --fidelity high
 extropy simulate -s asi-announcement --early-convergence off
 ```

--- a/extropy/cli/commands/config_cmd.py
+++ b/extropy/cli/commands/config_cmd.py
@@ -52,8 +52,8 @@ def config_command(
     Examples:
         extropy config show
         extropy config set models.fast openai/gpt-5-mini
-        extropy config set models.strong anthropic/claude-sonnet-4.5
-        extropy config set simulation.strong openrouter/anthropic/claude-sonnet-4.5
+        extropy config set models.strong anthropic/claude-sonnet-4-6
+        extropy config set simulation.strong openrouter/anthropic/claude-sonnet-4-6
         extropy config reset
     """
     if action == "show":

--- a/extropy/cli/commands/simulate.py
+++ b/extropy/cli/commands/simulate.py
@@ -107,7 +107,7 @@ def simulate_command(
         help="Scenario name (auto-selects if only one exists)",
     ),
     output: Path | None = typer.Option(
-        None, "--output", "-o", help="Output results directory (defaults to results/)"
+        None, "--output", "-o", help="Output results directory (defaults to results/{scenario}/)"
     ),
     strong: str = typer.Option(
         "",

--- a/extropy/cli/commands/validate.py
+++ b/extropy/cli/commands/validate.py
@@ -279,7 +279,7 @@ def validate_command(
     EXIT CODES:
         0 = Success (valid spec)
         1 = Validation error (invalid spec)
-        2 = File not found
+        3 = File not found
 
     EXAMPLES:
         extropy validate surgeons.yaml              # Population spec


### PR DESCRIPTION
## Summary

- `validate`: fix exit code in `--help` (was `2`, should be `3` for file not found)
- `config`: update model examples to `claude-sonnet-4-6`
- `simulate`: fix `--output` default description to `results/{scenario}/`
- `docs/commands.md`: update simulate example model name
- `AGENTS.md`: remove `--study-db` flag (doesn't exist on `chat ask`/`chat list`)

## Test plan

- [ ] `extropy validate --help` shows exit code 3 for file not found
- [ ] `extropy config --help` shows `claude-sonnet-4-6` examples
- [ ] `extropy simulate --help` shows correct `--output` default

🤖 Generated with [Claude Code](https://claude.com/claude-code)